### PR TITLE
feat(ui): add notification screen

### DIFF
--- a/app_ui/src/app/(tabs)/_layout.tsx
+++ b/app_ui/src/app/(tabs)/_layout.tsx
@@ -3,6 +3,7 @@ import TabLabel from "@/components/ui/TabLabel";
 import {
     Feather,
     FontAwesome5,
+    Ionicons,
     MaterialIcons,
     Octicons,
 } from "@expo/vector-icons";
@@ -44,6 +45,7 @@ const TabLayout = (props: Props) => {
                                 iconName="home"
                                 label="Trang chủ"
                                 {...props}
+                                size={20}
                             />
                         ),
                     }}
@@ -59,6 +61,7 @@ const TabLayout = (props: Props) => {
                                 iconName="users"
                                 label="Bạn bè"
                                 {...props}
+                                size={20}
                             />
                         ),
                     }}
@@ -74,6 +77,7 @@ const TabLayout = (props: Props) => {
                                 iconName="fire-alt"
                                 label="Bạn bè"
                                 {...props}
+                                size={20}
                             />
                         ),
                     }}
@@ -89,6 +93,22 @@ const TabLayout = (props: Props) => {
                                 iconName="chat-bubble-outline"
                                 label="Trò chuyện"
                                 {...props}
+                                size={20}
+                            />
+                        ),
+                    }}
+                />
+
+                <Tabs.Screen
+                    name="notification"
+                    options={{
+                        tabBarIcon: (props) => (
+                            <TabIcon
+                                Icon={Ionicons}
+                                iconName="notifications-outline"
+                                label="Thông báo"
+                                {...props}
+                                size={24}
                             />
                         ),
                     }}

--- a/app_ui/src/app/(tabs)/notification/_layout.tsx
+++ b/app_ui/src/app/(tabs)/notification/_layout.tsx
@@ -1,0 +1,15 @@
+import AppWrapper from "@/components/wrapper/AppWrapper";
+import { Slot } from "expo-router";
+import React from "react";
+
+type Props = {};
+
+const _layout = (props: Props) => {
+    return (
+        <AppWrapper>
+            <Slot></Slot>
+        </AppWrapper>
+    );
+};
+
+export default _layout;

--- a/app_ui/src/app/(tabs)/notification/index.tsx
+++ b/app_ui/src/app/(tabs)/notification/index.tsx
@@ -1,0 +1,106 @@
+import NotificationCard from "@/components/notification/NotificationCard";
+import NotificationGroup from "@/components/notification/NotificationGroup";
+import Button from "@/components/ui/Button";
+import SceenHeaderBack from "@/components/ui/SceenHeaderBack";
+import { AntDesign, Feather, Ionicons } from "@expo/vector-icons";
+import LottieView from "lottie-react-native";
+import React from "react";
+import { Dimensions, ScrollView, Text, View } from "react-native";
+
+type Props = {};
+const { width } = Dimensions.get("window");
+const index = (props: Props) => {
+    return (
+        <View style={{ width }} className="flex-1 w-full">
+            <SceenHeaderBack>Thông báo</SceenHeaderBack>
+            <ScrollView>
+                <NotificationGroup>
+                    <NotificationCard
+                        icon={
+                            <Ionicons
+                                name="ticket-outline"
+                                size={24}
+                                color="#f43f5e"
+                            />
+                        }
+                        iconColor="#f43f5e"
+                        title="Khuyễn mãi"
+                        description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptatem, alias ut. Consequuntur amet nemo non repellat quasi placeat aut impedit!"
+                        to="/home"
+                    />
+
+                    <NotificationCard
+                        icon={
+                            <Feather name="users" size={24} color="#22c55e" />
+                        }
+                        iconColor="#22c55e"
+                        title="Bạn bè"
+                        description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptatem, alias ut. Consequuntur amet nemo non repellat quasi placeat aut impedit!"
+                        to="/home"
+                    />
+
+                    <NotificationCard
+                        icon={
+                            <Feather
+                                name="shopping-bag"
+                                size={24}
+                                color="#3b82f6"
+                            />
+                        }
+                        iconColor="#3b82f6"
+                        title="Thông báo từ lemoo"
+                        description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptatem, alias ut. Consequuntur amet nemo non repellat quasi placeat aut impedit!"
+                        to="/home"
+                    />
+
+                    <NotificationCard
+                        icon={
+                            <AntDesign name="staro" size={24} color="#eab308" />
+                        }
+                        iconColor="#eab308"
+                        title="Cập nhật đánh giá"
+                        description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptatem, alias ut. Consequuntur amet nemo non repellat quasi placeat aut impedit!"
+                        to="/home"
+                    />
+                </NotificationGroup>
+                <NotificationGroup
+                    title="Cập nhật đơn hàng"
+                    linkLabel="Xem tất cả"
+                    to="/"
+                    className="flex-1 justify-center items-center"
+                >
+                    {/* {new Array(4).fill(0).map((item, index) => (
+                        <NotificationCard
+                            key={index}
+                            image="https://fakestoreapi.com/img/71-3HjGNDUL._AC_SY879._SX._UX._SY._UY_.jpg"
+                            title="Giao hàng thành công"
+                            description="Bạn vui lòng kiểm tra tất cả sản phẩm trong đơn hàng 190705010247AGP - đã giao ngày 08-07-2019. Nếu bạn hài lòng với sản phẩm, hãy xác nhận đã nhận hàng trong vòng 7 ngày để người bán được nhận tiền sớm hơn. Đừng quên đánh giá sản phẩm để nhận 100 xu nhé!"
+                            to="/home"
+                            descriptionLine={5}
+                        />
+                    ))} */}
+                    <View className="flex-1 justify-center items-center ">
+                        <LottieView
+                            style={{
+                                width: 100,
+                                height: 100,
+                                marginTop: 20,
+                            }}
+                            source={require("../../../assets/images/animations/empty-list.json")}
+                            autoPlay
+                            loop
+                        />
+                        <Text className="mt-2 mb-8 text-sm text-muded">
+                            Bạn chưa có đơn hàng nào
+                        </Text>
+                        <Button>
+                            <Text className="text-white">Mua Sắm ngay</Text>
+                        </Button>
+                    </View>
+                </NotificationGroup>
+            </ScrollView>
+        </View>
+    );
+};
+
+export default index;

--- a/app_ui/src/components/notification/NotificationCard.tsx
+++ b/app_ui/src/components/notification/NotificationCard.tsx
@@ -1,0 +1,68 @@
+import { cn } from "@/lib/cn";
+import { AntDesign } from "@expo/vector-icons";
+import React, { ReactNode } from "react";
+import { Dimensions, Image, Text, View } from "react-native";
+
+type Props = {
+    icon?: ReactNode;
+    iconColor?: string;
+    image?: string;
+    title: string;
+    description: string;
+    to: string;
+    descriptionLine?: number;
+};
+const { width } = Dimensions.get("window");
+const NotificationCard = ({
+    icon,
+    title,
+    description,
+    to,
+    descriptionLine = 1,
+    iconColor = "#f1f5f9",
+    image,
+}: Props) => {
+    return (
+        <View
+            style={{ width: width * 0.92 }}
+            className=" flex-row justify-start items-start px-2 py-3 gap-x-3 border-b border-b-slate-100  overflow-hidden"
+        >
+            {icon && (
+                <View
+                    className={cn(
+                        "p-3 flex-row justify-center items-center rounded-md border border-slate-100 "
+                    )}
+                    style={{
+                        borderColor: iconColor,
+                    }}
+                >
+                    {icon}
+                </View>
+            )}
+
+            {image && (
+                <View className="size-[50] rounded-md overflow-hidden">
+                    <Image
+                        className="w-full h-full object-cover"
+                        source={{ uri: image }}
+                    ></Image>
+                </View>
+            )}
+            <View className="">
+                <Text className=" font-semibold mb-1">{title}</Text>
+                <Text
+                    style={{ width: width * 0.65 }}
+                    className=" text-sm text-muded "
+                    numberOfLines={descriptionLine}
+                >
+                    {description}
+                </Text>
+            </View>
+            <View>
+                <AntDesign name="right" size={14} color="#94a3b8" />
+            </View>
+        </View>
+    );
+};
+
+export default NotificationCard;

--- a/app_ui/src/components/notification/NotificationGroup.tsx
+++ b/app_ui/src/components/notification/NotificationGroup.tsx
@@ -1,0 +1,39 @@
+import { cn } from "@/lib/cn";
+import { Link } from "expo-router";
+import React, { ReactNode } from "react";
+import { Dimensions, Text, View } from "react-native";
+
+type Props = {
+    children: ReactNode;
+    title?: string;
+    linkLabel?: string;
+    to?: string;
+    className?: string;
+};
+
+const { width } = Dimensions.get("window");
+const NotificationGroup = ({
+    children,
+    title,
+    className,
+    linkLabel,
+    to,
+}: Props) => {
+    return (
+        <View style={{ width: width * 0.9 }}>
+            <View className="flex-row items-center justify-between gap-2">
+                {title && (
+                    <Text className="font-semibold my-2 mx-1">{title}</Text>
+                )}
+                {linkLabel && to && (
+                    <Link className="text-primary text-sm" href={to as any}>
+                        {linkLabel}
+                    </Link>
+                )}
+            </View>
+            <View className={cn("my-2", className)}>{children}</View>
+        </View>
+    );
+};
+
+export default NotificationGroup;

--- a/app_ui/src/components/ui/TabIcon.tsx
+++ b/app_ui/src/components/ui/TabIcon.tsx
@@ -24,7 +24,7 @@ const TabIcon = ({
                 "flex-col justify-center items-center top-[8] absolute rounded-full"
             )}
         >
-            <Icon name={iconName} size={20} color={color}></Icon>
+            <Icon name={iconName} size={size} color={color}></Icon>
         </View>
     );
 };

--- a/app_ui/src/components/ui/TabLabel.tsx
+++ b/app_ui/src/components/ui/TabLabel.tsx
@@ -11,12 +11,16 @@ const screenTranslates: Record<string, string> = {
     friend: "Bạn bè",
     shorts: "Video",
     chats: "Tin nhắn",
+    notification: "Thông báo",
     profile: "Tôi",
 };
 
 const TabLabel = ({ children, color }: Props) => {
     return (
-        <Text style={{ color }} className="text-xs font-semibold mt-1 ">
+        <Text
+            style={{ color }}
+            className="text-xs font-semibold mt-1 text-center min-w-[140] "
+        >
             {screenTranslates[children]}
         </Text>
     );

--- a/app_ui/src/components/wrapper/AppWrapper.tsx
+++ b/app_ui/src/components/wrapper/AppWrapper.tsx
@@ -12,6 +12,7 @@ const AppWrapper = ({ children, className }: Props) => {
         <SafeAreaView
             style={{
                 maxWidth: width,
+                width,
             }}
             className={`flex-1  bg-white p-4 ${className}`}
         >


### PR DESCRIPTION
Adds notification tab and adjusts icons

Adds a notification tab to the bottom navigation.
Adjusts the tab icon size for better consistency across the app. Includes a text label with a min width for better alignment. Updates the app wrapper to use the screen width instead of max width for better layouts.