### PR TITLE
Adds internal store verification API

### DIFF
--- a/api/Store/src/main/java/com/lemoo/store/config/SecurityConfig.java
+++ b/api/Store/src/main/java/com/lemoo/store/config/SecurityConfig.java
@@ -25,25 +25,28 @@ import org.springframework.security.web.access.AccessDeniedHandler;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-	private final JwtAuthenticationConverter jwtAuthenticationConverter;
-	private final AccessDeniedHandler accessDeniedHandler;
-	private final AuthenticationEntryPoint authenticationEntryPoint;
+    private final JwtAuthenticationConverter jwtAuthenticationConverter;
+    private final AccessDeniedHandler accessDeniedHandler;
+    private final AuthenticationEntryPoint authenticationEntryPoint;
 
-	@Bean
-	SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-		http.csrf(AbstractHttpConfigurer::disable)
-				.sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-				.exceptionHandling(handler -> handler.authenticationEntryPoint(authenticationEntryPoint)
-						.accessDeniedHandler(accessDeniedHandler))
-				.authorizeHttpRequests(request -> request.anyRequest().authenticated())
-				.oauth2ResourceServer(
-						oauth -> oauth.jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter))
-								.authenticationEntryPoint(authenticationEntryPoint));
-		return http.build();
-	}
+    @Bean
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(handler -> handler.authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler))
+                .authorizeHttpRequests(request -> request
+                        .requestMatchers("/store/internal/**")
+                        .permitAll()
+                        .anyRequest().authenticated())
+                .oauth2ResourceServer(
+                        oauth -> oauth.jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter))
+                                .authenticationEntryPoint(authenticationEntryPoint));
+        return http.build();
+    }
 
-	@Bean
-	PasswordEncoder passwordEncoder() {
-		return new BCryptPasswordEncoder(10);
-	}
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder(10);
+    }
 }

--- a/api/Store/src/main/java/com/lemoo/store/controller/InternalStoreController.java
+++ b/api/Store/src/main/java/com/lemoo/store/controller/InternalStoreController.java
@@ -7,8 +7,26 @@
 
 package com.lemoo.store.controller;
 
+import com.lemoo.store.dto.request.VerifyStoreRequest;
+import com.lemoo.store.dto.response.ApiResponse;
+import com.lemoo.store.service.InternalStoreService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RestController("/internal")
+@RestController()
+@RequestMapping("/internal")
+@RequiredArgsConstructor
 public class InternalStoreController {
+    private final InternalStoreService internalStoreService;
+
+    @PostMapping("/verify")
+    public ApiResponse<?> verifyStore(
+            @RequestBody @Valid VerifyStoreRequest request
+    ) {
+        return ApiResponse.success(internalStoreService.verifyStore(request));
+    }
 }

--- a/api/Store/src/main/java/com/lemoo/store/dto/request/VerifyStoreRequest.java
+++ b/api/Store/src/main/java/com/lemoo/store/dto/request/VerifyStoreRequest.java
@@ -1,0 +1,18 @@
+/*
+ *  VerifyStoreRequest
+ *  @author: Minhhieuano
+ *  @created 12/26/2024 10:07 AM
+ * */
+
+
+package com.lemoo.store.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class VerifyStoreRequest {
+    private String accountId;
+    private String storeId;
+}

--- a/api/Store/src/main/java/com/lemoo/store/repository/StoreRepository.java
+++ b/api/Store/src/main/java/com/lemoo/store/repository/StoreRepository.java
@@ -20,6 +20,8 @@ public interface StoreRepository extends JpaRepository<Store, String> {
     @Query("select s from Store s where  s.status != 'INACTIVE' and s.ownerId = :ownerId")
     Optional<Store> findVerifiedStore(String ownerId);
 
+    boolean existsByIdAndOwnerId(String storeId, String ownerId);
+
     boolean existsByName(String name);
 
     boolean existsByNameOrOwnerId(String name, String ownerId);

--- a/api/Store/src/main/java/com/lemoo/store/service/InternalStoreService.java
+++ b/api/Store/src/main/java/com/lemoo/store/service/InternalStoreService.java
@@ -1,0 +1,13 @@
+/*
+ *  InternalStoreService
+ *  @author: Minhhieuano
+ *  @created 12/26/2024 5:48 PM
+ * */
+
+package com.lemoo.store.service;
+
+import com.lemoo.store.dto.request.VerifyStoreRequest;
+
+public interface InternalStoreService {
+    boolean verifyStore(VerifyStoreRequest request);
+}

--- a/api/Store/src/main/java/com/lemoo/store/service/impl/InternalStoreServiceImpl.java
+++ b/api/Store/src/main/java/com/lemoo/store/service/impl/InternalStoreServiceImpl.java
@@ -1,0 +1,26 @@
+/*
+ *  InternalStoreServiceImpl
+ *  @author: Minhhieuano
+ *  @created 12/26/2024 5:49 PM
+ * */
+
+
+package com.lemoo.store.service.impl;
+
+import com.lemoo.store.dto.request.VerifyStoreRequest;
+import com.lemoo.store.repository.StoreRepository;
+import com.lemoo.store.service.InternalStoreService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class InternalStoreServiceImpl implements InternalStoreService {
+
+    private final StoreRepository storeRepository;
+
+    @Override
+    public boolean verifyStore(VerifyStoreRequest request) {
+        return storeRepository.existsByIdAndOwnerId(request.getStoreId(), request.getAccountId());
+    }
+}


### PR DESCRIPTION
Adds an internal API endpoint for verifying stores based on store and owner IDs. This endpoint is secured to require authentication. It also configures the security filter chain to allow access to the internal API without authentication.