### PR TITLE
Adds separate DTOs for category requests

### DIFF
--- a/api/Product/src/main/java/com/lemoo/product/controller/CategoryController.java
+++ b/api/Product/src/main/java/com/lemoo/product/controller/CategoryController.java
@@ -6,7 +6,8 @@
 
 package com.lemoo.product.controller;
 
-import com.lemoo.product.dto.request.CategoryRequest;
+import com.lemoo.product.dto.request.CategoryRequestNoFile;
+import com.lemoo.product.dto.request.CategoryRequestWithFile;
 import com.lemoo.product.dto.response.ApiResponse;
 import com.lemoo.product.service.CategoryService;
 import jakarta.validation.Valid;
@@ -17,18 +18,25 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/categories")
 @RequiredArgsConstructor
 public class CategoryController {
-	private final CategoryService categoryService;
+    private final CategoryService categoryService;
 
-	@PostMapping
-	public ApiResponse<?> createCategory(@ModelAttribute @Valid CategoryRequest request) {
-		return ApiResponse.success(categoryService.createCategory(request));
-	}
+    @PostMapping("/file")
+    public ApiResponse<?> createCategoryWithFile(@ModelAttribute @Valid CategoryRequestWithFile request) {
+        return ApiResponse.success(categoryService.createCategory(request));
+    }
 
-	@GetMapping
-	public ApiResponse<?> getAllCategory(
-			@RequestParam(value = "page", required = false, defaultValue = "0") int page,
-			@RequestParam(value = "limit", required = false, defaultValue = "10") int limit,
-			@RequestParam(value = "parent", required = false) String parentId) {
-		return ApiResponse.success(categoryService.getAllCategoryByParentId(parentId, page, limit));
-	}
+    @PostMapping()
+    public ApiResponse<?> createCategory(@RequestBody @Valid CategoryRequestNoFile request) {
+        return ApiResponse.success(categoryService.createCategory(request));
+    }
+
+    @GetMapping
+    public ApiResponse<?> getAllCategory(
+            @RequestParam(value = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(value = "limit", required = false, defaultValue = "10") int limit,
+            @RequestParam(value = "parent", required = false) String parentId) {
+        return ApiResponse.success(categoryService.getAllCategoryByParentId(parentId, page, limit));
+    }
+
+
 }

--- a/api/Product/src/main/java/com/lemoo/product/dto/request/CategoryRequest.java
+++ b/api/Product/src/main/java/com/lemoo/product/dto/request/CategoryRequest.java
@@ -1,23 +1,21 @@
 /*
- *  CategoryRequest
+ *  CategoryRequestWithImageUrl
  *  @author: Minhhieuano
- *  @created 12/14/2024 8:46 AM
+ *  @created 12/29/2024 2:06 PM
  * */
+
 
 package com.lemoo.product.dto.request;
 
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
-import lombok.Builder;
 import lombok.Data;
 import org.springframework.web.multipart.MultipartFile;
 
 @Data
-@Builder
-public class CategoryRequest {
+public abstract class CategoryRequest {
     @NotEmpty
     private String name;
     private String parentId;
-    @NotNull
+    private String imageUrl;
     private MultipartFile image;
 }

--- a/api/Product/src/main/java/com/lemoo/product/dto/request/CategoryRequestNoFile.java
+++ b/api/Product/src/main/java/com/lemoo/product/dto/request/CategoryRequestNoFile.java
@@ -1,0 +1,20 @@
+/*
+ *  CategoryRequestNoFile
+ *  @author: Minhhieuano
+ *  @created 12/29/2024 2:16 PM
+ * */
+
+
+package com.lemoo.product.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class CategoryRequestNoFile extends CategoryRequest {
+
+    @NotEmpty
+    private String imageUrl;
+}

--- a/api/Product/src/main/java/com/lemoo/product/dto/request/CategoryRequestWithFile.java
+++ b/api/Product/src/main/java/com/lemoo/product/dto/request/CategoryRequestWithFile.java
@@ -1,0 +1,21 @@
+/*
+ *  CategoryRequest
+ *  @author: Minhhieuano
+ *  @created 12/14/2024 8:46 AM
+ * */
+
+package com.lemoo.product.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.springframework.web.multipart.MultipartFile;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+@Builder
+public class CategoryRequestWithFile extends CategoryRequest {
+    @NotNull
+    private MultipartFile image;
+}

--- a/api/Product/src/main/java/com/lemoo/product/service/impl/CategoryServiceImpl.java
+++ b/api/Product/src/main/java/com/lemoo/product/service/impl/CategoryServiceImpl.java
@@ -67,11 +67,17 @@ public class CategoryServiceImpl implements CategoryService {
             category.setPaths(paths);
         }
 
+        if (dto.getImageUrl() != null) {
+            category.setImage(dto.getImageUrl());
+        }
+
         Category newCategory = categoryRepository.save(category);
 
-        resourceService
-                .uploadImageAsync(dto.getImage().getBytes(), newCategory.getId(), "/categories")
-                .thenAccept((data) -> updateCategoryImage(category.getId(), data.getSecureUrl()));
+        if (dto.getImage() != null) {
+            resourceService
+                    .uploadImageAsync(dto.getImage().getBytes(), newCategory.getId(), "/categories")
+                    .thenAccept((data) -> updateCategoryImage(category.getId(), data.getSecureUrl()));
+        }
 
         return categoryMapper.categoryToCategoryResponse(newCategory);
     }
@@ -108,7 +114,7 @@ public class CategoryServiceImpl implements CategoryService {
                 .orElseThrow(() -> new NotfoundException("Category " + categoryId + " not found"));
     }
 
-    protected void updateCategoryImage(String categoryId, String image) {
+    private void updateCategoryImage(String categoryId, String image) {
         Category category = categoryRepository
                 .findById(categoryId)
                 .orElseThrow(() ->


### PR DESCRIPTION
Introduces `CategoryRequestWithImageUrl`, `CategoryRequestNoFile`, and `CategoryRequestWithFile` DTOs to support different image upload scenarios.  This allows for more flexible handling of category creation requests with or without image uploads.