### PR TITLE
Adds API endpoint for retrieving paginated shipping addresses

### DIFF
--- a/api/Shipping/src/main/java/com/lemoo/shipping/controller/BuyerShippingController.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/controller/BuyerShippingController.java
@@ -23,6 +23,15 @@ import org.springframework.web.bind.annotation.*;
 public class BuyerShippingController {
     private final ShippingAddressService shippingAddressService;
 
+    @GetMapping
+    public ApiResponse<?> getAllShippingAddress(
+            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "limit", required = false, defaultValue = "10") int limit,
+            @AuthenticationPrincipal AuthenticatedAccount account
+    ) {
+        return ApiResponse.success(shippingAddressService.getAllShipAddress(account, page, limit));
+    }
+
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<?> createShippingAddress(

--- a/api/Shipping/src/main/java/com/lemoo/shipping/dto/response/PageableResponse.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/dto/response/PageableResponse.java
@@ -1,0 +1,17 @@
+package com.lemoo.shipping.dto.response;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class PageableResponse<T> {
+    private int totalPages;
+    private int totalElements;
+    private int size;
+    private List<T> content;
+    private boolean first;
+    private boolean last;
+    private int pageNumber;
+    private boolean empty;
+}

--- a/api/Shipping/src/main/java/com/lemoo/shipping/mapper/PageMapper.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/mapper/PageMapper.java
@@ -1,0 +1,25 @@
+/*
+ *  PageMapper
+ *  @author: Minhhieuano
+ *  @created 10/3/2024 12:23 PM
+ * */
+
+package com.lemoo.shipping.mapper;
+
+import com.lemoo.shipping.dto.response.PageableResponse;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.springframework.data.domain.Page;
+
+@Mapper(componentModel = "spring")
+public interface PageMapper {
+    @Mapping(source = "totalPages", target = "totalPages")
+    @Mapping(source = "totalElements", target = "totalElements")
+    @Mapping(source = "size", target = "size")
+    @Mapping(source = "content", target = "content")
+    @Mapping(source = "first", target = "first")
+    @Mapping(source = "last", target = "last")
+    @Mapping(source = "number", target = "pageNumber")
+    @Mapping(source = "empty", target = "empty")
+    PageableResponse toPageableResponse(Page page);
+}

--- a/api/Shipping/src/main/java/com/lemoo/shipping/repository/ShippingAddressRepository.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/repository/ShippingAddressRepository.java
@@ -8,6 +8,8 @@
 package com.lemoo.shipping.repository;
 
 import com.lemoo.shipping.entity.ShippingAddress;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
@@ -15,5 +17,7 @@ import org.springframework.stereotype.Repository;
 public interface ShippingAddressRepository extends MongoRepository<ShippingAddress, String> {
 
     boolean existsByUserId(String userId);
+
+    Page<ShippingAddress> findAllByUserId(String userId, Pageable pageable);
 
 }

--- a/api/Shipping/src/main/java/com/lemoo/shipping/service/ShippingAddressService.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/service/ShippingAddressService.java
@@ -9,10 +9,13 @@ package com.lemoo.shipping.service;
 
 import com.lemoo.shipping.dto.common.AuthenticatedAccount;
 import com.lemoo.shipping.dto.request.ShippingAddressRequest;
+import com.lemoo.shipping.dto.response.PageableResponse;
 import com.lemoo.shipping.dto.response.ShippingAddressResponse;
 
 public interface ShippingAddressService {
 
     ShippingAddressResponse createShippingAddress(AuthenticatedAccount account, ShippingAddressRequest request);
+
+    PageableResponse<ShippingAddressResponse> getAllShipAddress(AuthenticatedAccount account, int page, int limit);
 
 }

--- a/api/Shipping/src/main/java/com/lemoo/shipping/service/impl/ShippingAddressServiceImpl.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/service/impl/ShippingAddressServiceImpl.java
@@ -9,12 +9,16 @@ package com.lemoo.shipping.service.impl;
 
 import com.lemoo.shipping.dto.common.AuthenticatedAccount;
 import com.lemoo.shipping.dto.request.ShippingAddressRequest;
+import com.lemoo.shipping.dto.response.PageableResponse;
 import com.lemoo.shipping.dto.response.ShippingAddressResponse;
 import com.lemoo.shipping.entity.ShippingAddress;
+import com.lemoo.shipping.mapper.PageMapper;
 import com.lemoo.shipping.mapper.ShippingAddressMapper;
 import com.lemoo.shipping.repository.ShippingAddressRepository;
 import com.lemoo.shipping.service.ShippingAddressService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -22,6 +26,7 @@ import org.springframework.stereotype.Service;
 public class ShippingAddressServiceImpl implements ShippingAddressService {
     private final ShippingAddressRepository shippingAddressRepository;
     private final ShippingAddressMapper shippingAddressMapper;
+    private final PageMapper pageMapper;
 
     @Override
     public ShippingAddressResponse createShippingAddress(AuthenticatedAccount account, ShippingAddressRequest request) {
@@ -33,5 +38,12 @@ public class ShippingAddressServiceImpl implements ShippingAddressService {
         shippingAddress.setUserId(account.getUserId());
 
         return shippingAddressMapper.toShippingAddressResponse(shippingAddressRepository.save(shippingAddress));
+    }
+
+    @Override
+    public PageableResponse<ShippingAddressResponse> getAllShipAddress(AuthenticatedAccount account, int page, int limit) {
+        PageRequest request = PageRequest.of(page, limit);
+        Page<?> shippingAddresses = shippingAddressRepository.findAllByUserId(account.getUserId(), request);
+        return pageMapper.toPageableResponse(shippingAddresses);
     }
 }


### PR DESCRIPTION
Implements an endpoint to retrieve all shipping addresses for a user in a paginated format.

Includes a new PageableResponse DTO for handling pagination data.

Creates a mapper to convert Spring's Page object to the PageableResponse.

Modifies the repository to support pagination.

Updates the service layer to retrieve and process paginated results.