### PR TITLE
Refactor exception handling and mapper initialization; remove unused …

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "codetogether.virtualCursorJoin": "sharedVirtualCursor"
-}

--- a/api/Chat/src/main/java/com/lemoo/chat/exception/GlobalExceptionHandler.java
+++ b/api/Chat/src/main/java/com/lemoo/chat/exception/GlobalExceptionHandler.java
@@ -7,8 +7,6 @@
 package com.lemoo.chat.exception;
 
 import com.lemoo.chat.dto.response.ApiResponse;
-import java.util.HashMap;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,30 +15,33 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
-	@ExceptionHandler(ApiException.class)
-	public ResponseEntity<ApiResponse<?>> handleApiException(ApiException exception) {
-		ApiResponse<?> response = ApiResponse.error(exception.getMessage());
-		log.info(exception.getMessage());
-		return new ResponseEntity<>(response, exception.getStatus());
-	}
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ApiResponse<Object>> handleApiException(ApiException exception) {
+        ApiResponse<Object> response = ApiResponse.error(exception.getMessage());
+        log.info(exception.getMessage());
+        return new ResponseEntity<>(response, exception.getStatus());
+    }
 
-	@ExceptionHandler(Exception.class)
-	public ResponseEntity<ApiResponse<?>> handleException(Exception exception) {
-		ApiResponse<?> response = ApiResponse.error(exception.getMessage());
-		log.error(exception.getMessage());
-		return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
-	}
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Object>> handleException(Exception exception) {
+        ApiResponse<Object> response = ApiResponse.error(exception.getMessage());
+        log.error(exception.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
 
-	@ExceptionHandler(MethodArgumentNotValidException.class)
-	public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
-		Map<String, Object> errors = new HashMap<>();
-		log.info("Validation failed {}", ex.getMessage());
-		for (FieldError fieldError : ex.getBindingResult().getFieldErrors()) {
-			errors.put(fieldError.getField(), fieldError.getDefaultMessage());
-		}
-		return new ResponseEntity<>(ApiResponse.error(errors), ex.getStatusCode());
-	}
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Object>> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        Map<String, Object> errors = new HashMap<>();
+        log.info("Validation failed {}", ex.getMessage());
+        for (FieldError fieldError : ex.getBindingResult().getFieldErrors()) {
+            errors.put(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+        return new ResponseEntity<>(ApiResponse.error(errors), ex.getStatusCode());
+    }
 }

--- a/api/Chat/src/main/java/com/lemoo/chat/mapper/RoomMapper.java
+++ b/api/Chat/src/main/java/com/lemoo/chat/mapper/RoomMapper.java
@@ -14,16 +14,17 @@ import com.lemoo.chat.entity.SingleRoom;
 import com.lemoo.chat.service.UserService;
 import org.mapstruct.Mapper;
 import org.mapstruct.Named;
-import org.springframework.beans.factory.annotation.Autowired;
 
 @Mapper(componentModel = "spring")
 public abstract class RoomMapper {
 
-    @Autowired
-    protected UserClient userClient;
+    protected final UserClient userClient;
+    protected final UserService userService;
 
-    @Autowired
-    protected UserService userService;
+    RoomMapper(UserClient userClient, UserService userService) {
+        this.userClient = userClient;
+        this.userService = userService;
+    }
 
     @Named("toRoomResponse")
     public RoomResponse toRoomResponse(Room room, String currentUserId) {

--- a/api/Chat/src/main/java/com/lemoo/chat/security/CustomAccessDeniedException.java
+++ b/api/Chat/src/main/java/com/lemoo/chat/security/CustomAccessDeniedException.java
@@ -9,27 +9,28 @@ package com.lemoo.chat.security;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
+import java.io.IOException;
+
 @Component
 public class CustomAccessDeniedException implements AccessDeniedHandler {
 
-	private HandlerExceptionResolver resolver;
+    private final HandlerExceptionResolver resolver;
 
-	public CustomAccessDeniedException(
-			@Qualifier("handlerExceptionResolver") HandlerExceptionResolver handlerExceptionResolver) {
-		this.resolver = handlerExceptionResolver;
-	}
+    public CustomAccessDeniedException(
+            @Qualifier("handlerExceptionResolver") HandlerExceptionResolver handlerExceptionResolver) {
+        this.resolver = handlerExceptionResolver;
+    }
 
-	@Override
-	public void handle(
-			HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException)
-			throws IOException, ServletException {
-		resolver.resolveException(request, response, null, accessDeniedException);
-	}
+    @Override
+    public void handle(
+            HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException)
+            throws IOException, ServletException {
+        resolver.resolveException(request, response, null, accessDeniedException);
+    }
 }

--- a/api/Chat/src/main/java/com/lemoo/chat/service/impl/RoomServiceImpl.java
+++ b/api/Chat/src/main/java/com/lemoo/chat/service/impl/RoomServiceImpl.java
@@ -55,7 +55,7 @@ public class RoomServiceImpl implements RoomService {
         Page<Room> rooms = roomRepository.findAllByAccountInMember(account.getUserId(), request);
 
         Page<RoomResponse> responses = rooms.map(
-                (room) -> CompletableFuture.supplyAsync(() -> roomMapper.toRoomResponse(room, account.getUserId()))
+                room -> CompletableFuture.supplyAsync(() -> roomMapper.toRoomResponse(room, account.getUserId()))
         ).map(CompletableFuture::join);
         return pageMapper.toPageableResponse(responses);
     }


### PR DESCRIPTION
This pull request includes several changes aimed at refactoring and cleaning up the codebase in the `api/Chat` module. The most important changes involve modifying exception handling, updating class constructors, and reordering imports.

### Exception Handling Improvements:
* [`api/Chat/src/main/java/com/lemoo/chat/exception/GlobalExceptionHandler.java`](diffhunk://#diff-d131ddf5c37ca703a8239fce46ede0fca5af4ecef27974b59b530277d8a94b04R18-R39): Changed the generic type of `ApiResponse` from `<?>` to `<Object>` in the exception handler methods to improve type safety.

### Constructor Updates:
* [`api/Chat/src/main/java/com/lemoo/chat/mapper/RoomMapper.java`](diffhunk://#diff-33e6ab9c0abd28587796cacb69a48a957474dbcb108b557f93a2ea1c0fa46434L17-R27): Changed the `RoomMapper` class to use constructor injection instead of field injection for `UserClient` and `UserService`.
* [`api/Chat/src/main/java/com/lemoo/chat/security/CustomAccessDeniedException.java`](diffhunk://#diff-7e8731f3cf8e7997b129a8107730e77aa5aa4140f40a4e4642c7a47fb35aa480L12-R23): Updated the `CustomAccessDeniedException` class to use a final field for `HandlerExceptionResolver` and constructor injection.

### Code Clean-up:
* [`api/Chat/src/main/java/com/lemoo/chat/service/impl/RoomServiceImpl.java`](diffhunk://#diff-0defea9d1c46607cc1baf2bb6d1d71b74abab89c584d92496de8fb93abda7404L58-R58): Simplified the lambda expression in the `getAllRoom` method.

### Import Reordering:
* [`api/Chat/src/main/java/com/lemoo/chat/exception/GlobalExceptionHandler.java`](diffhunk://#diff-d131ddf5c37ca703a8239fce46ede0fca5af4ecef27974b59b530277d8a94b04L10-L11): Reordered imports to follow standard conventions.