### PR TITLE
Adds pagination to message retrieval

### DIFF
--- a/api/Chat/src/main/java/com/lemoo/chat/controller/MessageController.java
+++ b/api/Chat/src/main/java/com/lemoo/chat/controller/MessageController.java
@@ -11,6 +11,7 @@ import com.lemoo.chat.dto.common.AuthenticatedAccount;
 import com.lemoo.chat.dto.request.MessageRequest;
 import com.lemoo.chat.dto.response.ApiResponse;
 import com.lemoo.chat.dto.response.MessageResponse;
+import com.lemoo.chat.dto.response.PageableResponse;
 import com.lemoo.chat.service.MessageService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,15 @@ import org.springframework.web.bind.annotation.*;
 public class MessageController {
     private final MessageService messageService;
 
+    @GetMapping
+    public ApiResponse<PageableResponse<MessageResponse>> getMessages(
+            @PathVariable("roomId") String roomId,
+            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "limit", required = false, defaultValue = "10") int limit,
+            @AuthenticationPrincipal AuthenticatedAccount account
+    ) {
+        return ApiResponse.success(messageService.getMessage(roomId, page, limit, account));
+    }
 
     @PostMapping
     public ApiResponse<MessageResponse> sendMessage(

--- a/api/Chat/src/main/java/com/lemoo/chat/repository/MessageRepository.java
+++ b/api/Chat/src/main/java/com/lemoo/chat/repository/MessageRepository.java
@@ -7,10 +7,12 @@
 package com.lemoo.chat.repository;
 
 import com.lemoo.chat.entity.Message;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MessageRepository extends MongoRepository<Message, String> {
-    
+    Page<Message> findAllByRoomId(String roomId, Pageable pageable);
 }

--- a/api/Chat/src/main/java/com/lemoo/chat/service/MessageService.java
+++ b/api/Chat/src/main/java/com/lemoo/chat/service/MessageService.java
@@ -9,7 +9,16 @@ package com.lemoo.chat.service;
 import com.lemoo.chat.dto.common.AuthenticatedAccount;
 import com.lemoo.chat.dto.request.MessageRequest;
 import com.lemoo.chat.dto.response.MessageResponse;
+import com.lemoo.chat.dto.response.PageableResponse;
 
 public interface MessageService {
     MessageResponse createMessage(MessageRequest request, String roomId, AuthenticatedAccount account);
+
+    PageableResponse<MessageResponse> getMessage(
+            String roomId,
+            int page,
+            int limit,
+            AuthenticatedAccount account
+    );
+
 }

--- a/api/Chat/src/main/java/com/lemoo/chat/service/impl/MessageServiceImpl.java
+++ b/api/Chat/src/main/java/com/lemoo/chat/service/impl/MessageServiceImpl.java
@@ -10,15 +10,22 @@ package com.lemoo.chat.service.impl;
 import com.lemoo.chat.dto.common.AuthenticatedAccount;
 import com.lemoo.chat.dto.request.MessageRequest;
 import com.lemoo.chat.dto.response.MessageResponse;
+import com.lemoo.chat.dto.response.PageableResponse;
 import com.lemoo.chat.entity.Message;
 import com.lemoo.chat.entity.Room;
 import com.lemoo.chat.mapper.MessageMapper;
+import com.lemoo.chat.mapper.PageMapper;
 import com.lemoo.chat.repository.MessageRepository;
 import com.lemoo.chat.service.MessageService;
 import com.lemoo.chat.service.RoomService;
 import com.lemoo.chat.service.RoomValidatorService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+
+import java.util.concurrent.CompletableFuture;
 
 @Service
 @RequiredArgsConstructor
@@ -27,13 +34,14 @@ public class MessageServiceImpl implements MessageService {
     private final RoomValidatorService roomValidatorService;
     private final RoomService roomService;
     private final MessageMapper messageMapper;
+    private final PageMapper pageMapper;
 
     @Override
     public MessageResponse createMessage(MessageRequest request, String roomId, AuthenticatedAccount account) {
         Room room = roomService.findRoomById(roomId);
         // check member permission
         roomValidatorService.validateRoomAccessPermission(room, account.getUserId());
-        
+
         Message message = messageRepository.save(Message
                 .builder()
                 .roomId(roomId)
@@ -42,5 +50,24 @@ public class MessageServiceImpl implements MessageService {
                 .build()
         );
         return messageMapper.toMessageResponse(message);
+    }
+
+    @Override
+    public PageableResponse<MessageResponse> getMessage(String roomId, int page, int limit, AuthenticatedAccount account) {
+        Room room = roomService.findRoomById(roomId);
+        roomValidatorService.validateRoomAccessPermission(room, account.getUserId());
+
+        PageRequest request = PageRequest.of(page, limit, Sort.by(Sort.Direction.ASC, "createdAt"));
+        Page<Message> messages = messageRepository.findAllByRoomId(roomId, request);
+
+        Page<MessageResponse> messageResponses = messages.map((message) ->
+                CompletableFuture.supplyAsync(() -> {
+                    boolean isSelf = message.getSenderId().equals(account.getUserId());
+                    if (isSelf) return messageMapper.toMessageResponse(message);
+                    else return messageMapper.toMessageResponse(message, message.getSenderId());
+                })
+        ).map(CompletableFuture::join);
+
+        return pageMapper.toPageableResponse(messageResponses);
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature to retrieve paginated messages from a chat room. Major changes include adding a new endpoint in the `MessageController`, updating the `MessageRepository` and `MessageService` interfaces, and implementing the new functionality in `MessageServiceImpl`.

### New Feature: Paginated Message Retrieval

* [`api/Chat/src/main/java/com/lemoo/chat/controller/MessageController.java`](diffhunk://#diff-0b21b81e65fdd7b47564ed1c4572546e462837db54450b160f1e5442ced77043R27-R35): Added a new `getMessages` endpoint to retrieve paginated messages for a specific chat room.
* [`api/Chat/src/main/java/com/lemoo/chat/repository/MessageRepository.java`](diffhunk://#diff-a3f826168853eb35b2692c103cd547048fae227f304be112dc4a559106930f4bR10-R17): Added a new method `findAllByRoomId` to fetch messages by room ID with pagination support.
* [`api/Chat/src/main/java/com/lemoo/chat/service/MessageService.java`](diffhunk://#diff-effd7df5bed9cad3797080d1026934aa29bd2957158e7aef471c712e87101d65R12-R23): Added a new method `getMessage` to the `MessageService` interface for retrieving paginated messages.
* [`api/Chat/src/main/java/com/lemoo/chat/service/impl/MessageServiceImpl.java`](diffhunk://#diff-593f23d603a05ddfdd8939fa1df13932ae4a1bc6a40be85c53ddf45a97cd46bfR54-R72): Implemented the `getMessage` method to handle pagination, validation, and mapping of messages.

### Supporting Changes

* [`api/Chat/src/main/java/com/lemoo/chat/controller/MessageController.java`](diffhunk://#diff-0b21b81e65fdd7b47564ed1c4572546e462837db54450b160f1e5442ced77043R14): Imported `PageableResponse` to support the new endpoint.
* [`api/Chat/src/main/java/com/lemoo/chat/service/impl/MessageServiceImpl.java`](diffhunk://#diff-593f23d603a05ddfdd8939fa1df13932ae4a1bc6a40be85c53ddf45a97cd46bfR13-R37): Imported `PageableResponse`, `PageMapper`, and pagination-related classes to support the implementation of the new method.