### PR TITLE
Adds contact sidebar items

### DIFF
--- a/ui/lemoo_chat/src/components/header/Header.tsx
+++ b/ui/lemoo_chat/src/components/header/Header.tsx
@@ -1,5 +1,5 @@
 import AddGroupButton from "./AddGroupButton";
-import UserSearch from "./userSearch";
+import UserSearch from "./UserSearch";
 
 type Props = {};
 

--- a/ui/lemoo_chat/src/modules/sidebar/ContactSidebar.tsx
+++ b/ui/lemoo_chat/src/modules/sidebar/ContactSidebar.tsx
@@ -1,5 +1,7 @@
 import Header from "@/components/header/Header";
 import { cn } from "@/lib/utils";
+import { Send, UserCheck, UsersRound } from "lucide-react";
+import ContactSidebarItem from "./ContactSidebarItem";
 
 type Props = {
     className?: string;
@@ -8,7 +10,18 @@ type Props = {
 const ContactSidebar = ({ className }: Props) => {
     return (
         <div className={cn("", className)}>
-            <Header></Header>{" "}
+            <Header></Header>
+            <div>
+                <ContactSidebarItem to="/contacts" icon={<UsersRound />}>
+                    Danh sách bạn bè
+                </ContactSidebarItem>
+                <ContactSidebarItem to="/contacts/request" icon={<UserCheck />}>
+                    Lời mời kết bạn
+                </ContactSidebarItem>
+                <ContactSidebarItem to="/contacts/sent" icon={<Send />}>
+                    Lời mời đã gửi
+                </ContactSidebarItem>
+            </div>
         </div>
     );
 };

--- a/ui/lemoo_chat/src/modules/sidebar/ContactSidebarItem.tsx
+++ b/ui/lemoo_chat/src/modules/sidebar/ContactSidebarItem.tsx
@@ -1,0 +1,22 @@
+import { Link, LinkProps, ReactNode } from "@tanstack/react-router";
+
+type Props = {
+    icon: ReactNode;
+    children: ReactNode;
+} & LinkProps;
+
+const ContactSidebarItem = ({ icon, children, ...props }: Props) => {
+    return (
+        <Link
+            className="flex justify-start items-center gap-5 px-5 py-4 hover:bg-stone-400/10 cursor-pointer transition-all"
+            activeOptions={{ exact: true }}
+            activeProps={{ className: "!bg-primary/10 " }}
+            {...props}
+        >
+            <span className="[&_svg]:size-[20px]">{icon}</span>
+            <span>{children}</span>
+        </Link>
+    );
+};
+
+export default ContactSidebarItem;


### PR DESCRIPTION
This pull request includes several changes to the `ui/lemoo_chat` module, focusing on improving the sidebar functionality and fixing a minor import issue. The most important changes include the addition of a new `ContactSidebarItem` component and the integration of this component into the `ContactSidebar`. 

Improvements to the sidebar functionality:

* [`ui/lemoo_chat/src/modules/sidebar/ContactSidebarItem.tsx`](diffhunk://#diff-c24ab330358ffe1939597187a92c96dc740b2f3be54fff7d64a852a77a393706R1-R22): Added a new `ContactSidebarItem` component to handle sidebar items with icons and links.
* [`ui/lemoo_chat/src/modules/sidebar/ContactSidebar.tsx`](diffhunk://#diff-4a40b1b736212954b8f214d4e38af49b2d14d4a9d61a1d2c605ad18e9f69123aL11-R24): Integrated the `ContactSidebarItem` component into the `ContactSidebar` to display a list of contacts, friend requests, and sent invitations.

Minor fixes:

* [`ui/lemoo_chat/src/components/header/Header.tsx`](diffhunk://#diff-0d85f57a11043ac7f561618d3775fd139abe2f146553d97f58ff5b5a72ed5ca8L2-R2): Corrected the import statement for `UserSearch` to use the correct casing.
* [`ui/lemoo_chat/src/modules/sidebar/ContactSidebar.tsx`](diffhunk://#diff-4a40b1b736212954b8f214d4e38af49b2d14d4a9d61a1d2c605ad18e9f69123aR3-R4): Added imports for `Send`, `UserCheck`, and `UsersRound` icons from `lucide-react`.