### PR TITLE
Move url config to env file

### DIFF
--- a/ui/lemoo_chat/src/context/SocketContext.tsx
+++ b/ui/lemoo_chat/src/context/SocketContext.tsx
@@ -34,7 +34,7 @@ const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
         }
 
         const newClient = new Client({
-            brokerURL: "ws://localhost:4008/ws",
+            brokerURL: import.meta.env.VITE_SOCKET_BASE_URL,
             debug: function (str) {
                 // console.log("STOMP Debug:", str);
             },

--- a/ui/lemoo_chat/src/lib/api.ts
+++ b/ui/lemoo_chat/src/lib/api.ts
@@ -4,8 +4,7 @@ import axios from "axios";
 import { memoizedRefreshToken } from "./refreshToken";
 
 export const api = axios.create({
-    baseURL: "https://mock.apidog.com/m1/730971-0-default",
-    // baseURL: "http://143.244.150.42/api/v1",
+    baseURL: import.meta.env.VITE_API_BASE_URL,
     withCredentials: false,
 });
 


### PR DESCRIPTION
This pull request includes changes to externalize configuration values for the WebSocket and API base URLs by using environment variables. This improves the flexibility and security of the application by allowing these values to be set dynamically based on the deployment environment.

Configuration changes:

* [`ui/lemoo_chat/src/context/SocketContext.tsx`](diffhunk://#diff-7a966ed2b81805798b28a181107d811075b448fcf5711c98e5c4406cf050de40L37-R37): Updated the WebSocket broker URL to use the `VITE_SOCKET_BASE_URL` environment variable instead of a hardcoded URL.
* [`ui/lemoo_chat/src/lib/api.ts`](diffhunk://#diff-6483c991891c646a6bc718098ea530f3b40eb7167d805905b31aaa53c134dffdL7-R7): Updated the API base URL to use the `VITE_API_BASE_URL` environment variable instead of a hardcoded URL.