### PR TITLE
Adds group chat room creation API

### DIFF
--- a/api/Chat/src/main/java/com/lemoo/chat/controller/GroupController.java
+++ b/api/Chat/src/main/java/com/lemoo/chat/controller/GroupController.java
@@ -1,0 +1,36 @@
+/*
+ *  GroupController
+ *  @author: Minhhieuano
+ *  @created 2/14/2025 5:05 PM
+ * */
+
+
+package com.lemoo.chat.controller;
+
+import com.lemoo.chat.dto.common.AuthenticatedAccount;
+import com.lemoo.chat.dto.request.GroupRoomRequest;
+import com.lemoo.chat.dto.response.ApiResponse;
+import com.lemoo.chat.service.RoomService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/rooms")
+@RequiredArgsConstructor
+public class GroupController {
+    private final RoomService roomService;
+
+    @PostMapping
+    public ApiResponse<Boolean> createRoom(
+            @RequestBody @Valid GroupRoomRequest request,
+            @AuthenticationPrincipal AuthenticatedAccount account
+    ) {
+        return ApiResponse.success(roomService.createGroupRoom(request, account));
+    }
+
+}

--- a/api/Chat/src/main/java/com/lemoo/chat/dto/request/GroupRoomRequest.java
+++ b/api/Chat/src/main/java/com/lemoo/chat/dto/request/GroupRoomRequest.java
@@ -1,0 +1,18 @@
+/*
+ *  GroupRoomRequest
+ *  @author: Minhhieuano
+ *  @created 2/14/2025 5:06 PM
+ * */
+
+
+package com.lemoo.chat.dto.request;
+
+import lombok.Data;
+
+import java.util.Set;
+
+@Data
+public class GroupRoomRequest {
+    private String name;
+    private Set<String> members;
+}

--- a/api/Chat/src/main/java/com/lemoo/chat/service/RoomService.java
+++ b/api/Chat/src/main/java/com/lemoo/chat/service/RoomService.java
@@ -7,6 +7,7 @@
 package com.lemoo.chat.service;
 
 import com.lemoo.chat.dto.common.AuthenticatedAccount;
+import com.lemoo.chat.dto.request.GroupRoomRequest;
 import com.lemoo.chat.dto.response.PageableResponse;
 import com.lemoo.chat.dto.response.RoomDetailResponse;
 import com.lemoo.chat.dto.response.RoomResponse;
@@ -21,4 +22,6 @@ public interface RoomService {
     RoomDetailResponse getRoomDetail(String roomId, AuthenticatedAccount account);
 
     Room findRoomById(String roomId);
+
+    boolean createGroupRoom(GroupRoomRequest request, AuthenticatedAccount account);
 }

--- a/api/Chat/src/main/java/com/lemoo/chat/service/impl/RoomServiceImpl.java
+++ b/api/Chat/src/main/java/com/lemoo/chat/service/impl/RoomServiceImpl.java
@@ -8,9 +8,11 @@ package com.lemoo.chat.service.impl;
 
 import com.lemoo.chat.common.enums.RoomType;
 import com.lemoo.chat.dto.common.AuthenticatedAccount;
+import com.lemoo.chat.dto.request.GroupRoomRequest;
 import com.lemoo.chat.dto.response.PageableResponse;
 import com.lemoo.chat.dto.response.RoomDetailResponse;
 import com.lemoo.chat.dto.response.RoomResponse;
+import com.lemoo.chat.entity.GroupRoom;
 import com.lemoo.chat.entity.Room;
 import com.lemoo.chat.entity.SingleRoom;
 import com.lemoo.chat.exception.NotfoundException;
@@ -50,6 +52,17 @@ public class RoomServiceImpl implements RoomService {
         roomRepository.save(room);
     }
 
+    @Override
+    public boolean createGroupRoom(GroupRoomRequest request, AuthenticatedAccount account) {
+        Set<String> validMembers = roomValidatorService.validateMemberRequest(request.getMembers());
+        validMembers.add(account.getUserId());
+
+        roomRepository.save(GroupRoom.builder()
+                .owner(account.getUserId())
+                .members(validMembers)
+                .build());
+        return true;
+    }
 
     @Override
     public PageableResponse<RoomResponse> getAllRoom(int page, int limit, AuthenticatedAccount account) {
@@ -76,4 +89,6 @@ public class RoomServiceImpl implements RoomService {
         return roomRepository.findById(roomId)
                 .orElseThrow(() -> new NotfoundException("Room not found"));
     }
+
+
 }


### PR DESCRIPTION
Implements a new API endpoint for creating group chat rooms.  Includes validation for group room requests and integrates with the RoomService for persistence.  Also creates necessary DTOs and service methods.

This pull request introduces a new feature for creating group chat rooms in the chat application. The changes include the addition of a new controller, request DTO, and service method to handle the creation of group rooms.

Key changes:

### New Controller:
* Added `GroupController` class to handle HTTP requests for creating group rooms. (`api/Chat/src/main/java/com/lemoo/chat/controller/GroupController.java`)

### New DTO:
* Added `GroupRoomRequest` class to represent the request payload for creating a group room. (`api/Chat/src/main/java/com/lemoo/chat/dto/request/GroupRoomRequest.java`)

### Service Layer Updates:
* Updated `RoomService` interface to include a new method `createGroupRoom`. (`api/Chat/src/main/java/com/lemoo/chat/service/RoomService.java`)
* Implemented the `createGroupRoom` method in `RoomServiceImpl` to handle the logic for creating a group room and saving it to the repository. (`api/Chat/src/main/java/com/lemoo/chat/service/impl/RoomServiceImpl.java`)

These changes collectively enable the functionality for users to create group chat rooms within the application.