### PR TITLE
Updates Dockerfiles for Java services

### DIFF
--- a/api/Admin/Dockerfile
+++ b/api/Admin/Dockerfile
@@ -1,5 +1,5 @@
-FROM openjdk:17-jdk-alpine
+FROM openjdk:17-jdk-slim
 LABEL authors="Minhhieuano"
 LABEL description="Admin service v1"
 COPY target/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-jar", "/app.jar"]

--- a/api/Auth/Dockerfile
+++ b/api/Auth/Dockerfile
@@ -1,5 +1,5 @@
-FROM openjdk:17-jdk-alpine
+FROM openjdk:17-jdk-slim
 LABEL authors="Minhhieuano"
 LABEL description="Auth service v1"
 COPY target/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-jar", "/app.jar"]

--- a/api/Media/Dockerfile
+++ b/api/Media/Dockerfile
@@ -1,5 +1,5 @@
-FROM openjdk:17-jdk-alpine
+FROM openjdk:17-jdk-slim
 LABEL authors="Minhhieuano"
 LABEL description="Media service v1"
 COPY target/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-jar", "/app.jar"]

--- a/api/Notification/Dockerfile
+++ b/api/Notification/Dockerfile
@@ -1,5 +1,5 @@
-FROM openjdk:17-jdk-alpine
+FROM openjdk:17-jdk-slim
 LABEL authors="Minhhieuano"
 LABEL description="Notification service v1"
 COPY target/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-jar", "/app.jar"]

--- a/api/Product/Dockerfile
+++ b/api/Product/Dockerfile
@@ -1,5 +1,5 @@
-FROM openjdk:17-jdk-alpine
+FROM openjdk:17-jdk-slim
 LABEL authors="Minhhieuano"
 COPY target/*.jar app.jar
 LABEL description="Product service v1"
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-jar", "/app.jar"]

--- a/api/Promotion/Dockerfile
+++ b/api/Promotion/Dockerfile
@@ -1,5 +1,5 @@
-FROM openjdk:17-jdk-alpine
+FROM openjdk:17-jdk-slim
 LABEL authors="Minhhieuano"
 LABEL description="Promotion service v1"
 COPY target/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-jar", "/app.jar"]

--- a/api/Store/Dockerfile
+++ b/api/Store/Dockerfile
@@ -1,5 +1,5 @@
-FROM openjdk:17-jdk-alpine
+FROM openjdk:17-jdk-slim
 LABEL authors="Minhhieuano"
 LABEL description="Store service v1"
 COPY target/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-jar", "/app.jar"]

--- a/api/User/Dockerfile
+++ b/api/User/Dockerfile
@@ -1,5 +1,5 @@
-FROM openjdk:17-jdk-alpine
+FROM openjdk:17-jdk-slim
 LABEL authors="Minhhieuano"
 LABEL description="User service v1"
 COPY target/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-jar", "/app.jar"]

--- a/api/Video/Dockerfile
+++ b/api/Video/Dockerfile
@@ -1,5 +1,5 @@
-FROM openjdk:17-jdk-alpine
+FROM openjdk:17-jdk-slim
 LABEL authors="Minhhieuano"
 LABEL description="Video service v1"
 COPY target/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-jar", "/app.jar"]


### PR DESCRIPTION
Uses `openjdk:17-jdk-slim` image for all Java services. Adds `-XX:+UseContainerSupport` to Java ENTRYPOINT for better container performance.

This pull request includes updates to multiple Dockerfiles across different services to use a different base image and improve Java runtime settings. The most important changes include switching from `openjdk:17-jdk-alpine` to `openjdk:17-jdk-slim` and adding the `-XX:+UseContainerSupport` JVM option.

Changes to Dockerfiles:

* Updated base image from `openjdk:17-jdk-alpine` to `openjdk:17-jdk-slim` in the Dockerfiles for the following services: Admin, Auth, Media, Notification, Product, Promotion, Store, User, and Video. [[1]](diffhunk://#diff-493ec16449ec310090cb6d73ba09329a23a63a663cf586d81ba363511175827dL1-R5) [[2]](diffhunk://#diff-131c15919fbe101c8a1072f9af1b36fbb2fb7c2b7ea6610fc55e952f6315c7b0L1-R5) [[3]](diffhunk://#diff-b2614d49bcb532e217ceba86a01e01d227a9e92ad2ece3e02c2362d2f2465101L1-R5) [[4]](diffhunk://#diff-07a170ad3d0ddcf07a87f36eec73c9444bf49a0cd8c523323989d1bcc334855eL1-R5) [[5]](diffhunk://#diff-f3372003d3d4c00be091f57b406f59c8367d67e8e35d96cd7d01b927d566b127L1-R5) [[6]](diffhunk://#diff-479bd1609355b3b65f4189f3252cf9a954b2d92b44a17386d4f5b64796da03f7L1-R5) [[7]](diffhunk://#diff-4b03ec5a1752ebfea7216f3a620139b0d52c94f869c46371d53ae33a99b7b601L1-R5) [[8]](diffhunk://#diff-94e68120ff5e70333de168061d254656626acdbf8fee1536d7eebfb16a17acaaL1-R5) [[9]](diffhunk://#diff-e84f8d7fe81b859b6bc46b8a2bb1be04424dc597d98a8ddb5f2286a52e4bdc91L1-R5)
* Added `-XX:+UseContainerSupport` JVM option to the ENTRYPOINT command in the Dockerfiles for the following services: Admin, Auth, Media, Notification, Product, Promotion, Store, User, and Video. [[1]](diffhunk://#diff-493ec16449ec310090cb6d73ba09329a23a63a663cf586d81ba363511175827dL1-R5) [[2]](diffhunk://#diff-131c15919fbe101c8a1072f9af1b36fbb2fb7c2b7ea6610fc55e952f6315c7b0L1-R5) [[3]](diffhunk://#diff-b2614d49bcb532e217ceba86a01e01d227a9e92ad2ece3e02c2362d2f2465101L1-R5) [[4]](diffhunk://#diff-07a170ad3d0ddcf07a87f36eec73c9444bf49a0cd8c523323989d1bcc334855eL1-R5) [[5]](diffhunk://#diff-f3372003d3d4c00be091f57b406f59c8367d67e8e35d96cd7d01b927d566b127L1-R5) [[6]](diffhunk://#diff-479bd1609355b3b65f4189f3252cf9a954b2d92b44a17386d4f5b64796da03f7L1-R5) [[7]](diffhunk://#diff-4b03ec5a1752ebfea7216f3a620139b0d52c94f869c46371d53ae33a99b7b601L1-R5) [[8]](diffhunk://#diff-94e68120ff5e70333de168061d254656626acdbf8fee1536d7eebfb16a17acaaL1-R5) [[9]](diffhunk://#diff-e84f8d7fe81b859b6bc46b8a2bb1be04424dc597d98a8ddb5f2286a52e4bdc91L1-R5)