### PR TITLE
Adds store follow status endpoint

### DIFF
--- a/api/Store/src/main/java/com/lemoo/store/controller/StoreFollowerController.java
+++ b/api/Store/src/main/java/com/lemoo/store/controller/StoreFollowerController.java
@@ -21,6 +21,14 @@ import org.springframework.web.bind.annotation.*;
 public class StoreFollowerController {
     private final StoreFollowerService storeFollowerService;
 
+    @GetMapping("/follow/status")
+    public ApiResponse<Boolean> getStoreFollowStatus(
+            @PathVariable("storeId") String storeId,
+            @AuthenticationPrincipal AuthenticatedAccount account
+    ) {
+        return ApiResponse.success(storeFollowerService.getFollowStatus(storeId, account));
+    }
+
     @PostMapping("follow")
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<Boolean> followStore(

--- a/api/Store/src/main/java/com/lemoo/store/service/StoreFollowerService.java
+++ b/api/Store/src/main/java/com/lemoo/store/service/StoreFollowerService.java
@@ -9,6 +9,9 @@ package com.lemoo.store.service;
 import com.lemoo.store.dto.common.AuthenticatedAccount;
 
 public interface StoreFollowerService {
+
+    boolean getFollowStatus(String storeId, AuthenticatedAccount account);
+
     boolean followStore(String storeId, AuthenticatedAccount account);
 
     boolean unFollowStore(String storeId, AuthenticatedAccount account);

--- a/api/Store/src/main/java/com/lemoo/store/service/impl/StoreFollowerFollowerServiceImpl.java
+++ b/api/Store/src/main/java/com/lemoo/store/service/impl/StoreFollowerFollowerServiceImpl.java
@@ -14,6 +14,7 @@ import com.lemoo.store.repository.StoreRepository;
 import com.lemoo.store.service.StoreFollowerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +23,15 @@ public class StoreFollowerFollowerServiceImpl implements StoreFollowerService {
     private final StoreRepository storeRepository;
 
     @Override
+    @Transactional
+    public boolean getFollowStatus(String storeId, AuthenticatedAccount account) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new NotfoundException("Store " + storeId + " not found"));
+        return store.getFollowers().contains(account.getUserId());
+    }
+
+    @Override
+    @Transactional
     public boolean followStore(String storeId, AuthenticatedAccount account) {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new NotfoundException("Store " + storeId + " not found"));
@@ -35,6 +45,7 @@ public class StoreFollowerFollowerServiceImpl implements StoreFollowerService {
     }
 
     @Override
+    @Transactional
     public boolean unFollowStore(String storeId, AuthenticatedAccount account) {
 
         Store store = storeRepository.findById(storeId)


### PR DESCRIPTION
Implements an endpoint to retrieve the follow status of a store for a given user. This allows users to check if they are following a specific store before performing actions like adding comments.

This pull request adds a new feature to check the follow status of a store and includes several changes to the `StoreFollowerController` and `StoreFollowerService` classes, as well as their implementations. The most important changes are summarized below:

### New Feature: Check Follow Status

* [`api/Store/src/main/java/com/lemoo/store/controller/StoreFollowerController.java`](diffhunk://#diff-9318149a90293746d2a280013e084f2683b8ce616751b3684e1a93ed163cc427R24-R31): Added a new endpoint `GET /follow/status` to check if a user follows a specific store.
* [`api/Store/src/main/java/com/lemoo/store/service/StoreFollowerService.java`](diffhunk://#diff-cf8d0a249b7a3e06ef107b73d498c45b14fd3f792d04e56d42e65e200327c4e1R12-R14): Introduced a new method `getFollowStatus` in the `StoreFollowerService` interface.
* [`api/Store/src/main/java/com/lemoo/store/service/impl/StoreFollowerFollowerServiceImpl.java`](diffhunk://#diff-72fcfaea5f3e74d311a59fa8c3e76c6dbdf7eb0fed5ab6fc5706c29cee201bd4R26-R34): Implemented the `getFollowStatus` method to check if a user follows a store, including transactional support. [[1]](diffhunk://#diff-72fcfaea5f3e74d311a59fa8c3e76c6dbdf7eb0fed5ab6fc5706c29cee201bd4R26-R34) [[2]](diffhunk://#diff-72fcfaea5f3e74d311a59fa8c3e76c6dbdf7eb0fed5ab6fc5706c29cee201bd4R48)
* [`api/Store/src/main/java/com/lemoo/store/service/impl/StoreFollowerFollowerServiceImpl.java`](diffhunk://#diff-72fcfaea5f3e74d311a59fa8c3e76c6dbdf7eb0fed5ab6fc5706c29cee201bd4R17): Added the `@Transactional` annotation to the `followStore` and `unFollowStore` methods to ensure database consistency.