### PR TITLE
Adds endpoint to retrieve all regular vouchers

### DIFF
--- a/api/Promotion/src/main/java/com/lemoo/promotion/controller/RegularVoucherController.java
+++ b/api/Promotion/src/main/java/com/lemoo/promotion/controller/RegularVoucherController.java
@@ -11,6 +11,7 @@ import com.lemoo.promotion.common.constants.CustomRequestHeader;
 import com.lemoo.promotion.dto.common.AuthenticatedAccount;
 import com.lemoo.promotion.dto.request.RegularVoucherRequest;
 import com.lemoo.promotion.dto.response.ApiResponse;
+import com.lemoo.promotion.dto.response.PageableResponse;
 import com.lemoo.promotion.dto.response.RegularVoucherResponse;
 import com.lemoo.promotion.service.RegularVoucherService;
 import jakarta.validation.Valid;
@@ -33,6 +34,16 @@ public class RegularVoucherController {
             @RequestHeader(CustomRequestHeader.STORE_ID) String storeId
     ) {
         return ApiResponse.success(regularVoucherService.createVoucher(request, storeId, account));
+    }
+
+    @GetMapping
+    public ApiResponse<PageableResponse<RegularVoucherResponse>> getAllRegularVoucher(
+            @RequestParam(value = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(value = "limit", required = false, defaultValue = "10") int limit,
+            @RequestHeader(CustomRequestHeader.STORE_ID) String storeId,
+            @AuthenticationPrincipal AuthenticatedAccount account
+    ) {
+        return ApiResponse.success(regularVoucherService.findAllByStoreId(storeId, page, limit, account));
     }
 
     @GetMapping("/{voucherId}")

--- a/api/Promotion/src/main/java/com/lemoo/promotion/repository/BaseVoucherRepository.java
+++ b/api/Promotion/src/main/java/com/lemoo/promotion/repository/BaseVoucherRepository.java
@@ -8,6 +8,8 @@ package com.lemoo.promotion.repository;
 
 import com.lemoo.promotion.common.enums.VoucherType;
 import com.lemoo.promotion.entity.BaseVoucher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
@@ -23,6 +25,8 @@ public interface BaseVoucherRepository extends MongoRepository<BaseVoucher, Stri
     Optional<BaseVoucher> findByIdAndStoreIdAndVoucherType(String id, String storeId, VoucherType voucherType);
 
     Optional<BaseVoucher> findByIdAndVoucherType(String voucherId, VoucherType type);
+
+    Page<BaseVoucher> findAllByStoreIdAndVoucherType(String storeId, VoucherType type, Pageable pageable);
 
     boolean existsByNameAndStoreId(String name, String storeId);
 }

--- a/api/Promotion/src/main/java/com/lemoo/promotion/service/RegularVoucherService.java
+++ b/api/Promotion/src/main/java/com/lemoo/promotion/service/RegularVoucherService.java
@@ -8,12 +8,15 @@ package com.lemoo.promotion.service;
 
 import com.lemoo.promotion.dto.common.AuthenticatedAccount;
 import com.lemoo.promotion.dto.request.RegularVoucherRequest;
+import com.lemoo.promotion.dto.response.PageableResponse;
 import com.lemoo.promotion.dto.response.RegularVoucherResponse;
 
 public interface RegularVoucherService {
     String createVoucher(RegularVoucherRequest request, String storeId, AuthenticatedAccount account);
 
     RegularVoucherResponse findVoucherById(String voucherId, String storeId, AuthenticatedAccount account);
+
+    PageableResponse<RegularVoucherResponse> findAllByStoreId(String storeId, int page, int limit, AuthenticatedAccount account);
 
     void activateVoucher(String storeId, AuthenticatedAccount account, String voucherId);
 

--- a/api/Promotion/src/main/java/com/lemoo/promotion/service/impl/RegularVoucherServiceImpl.java
+++ b/api/Promotion/src/main/java/com/lemoo/promotion/service/impl/RegularVoucherServiceImpl.java
@@ -11,32 +11,60 @@ import com.lemoo.promotion.common.enums.VoucherType;
 import com.lemoo.promotion.dto.common.AuthenticatedAccount;
 import com.lemoo.promotion.dto.request.BaseVoucherRequest;
 import com.lemoo.promotion.dto.request.RegularVoucherRequest;
+import com.lemoo.promotion.dto.response.PageableResponse;
 import com.lemoo.promotion.dto.response.RegularVoucherResponse;
 import com.lemoo.promotion.entity.BaseVoucher;
 import com.lemoo.promotion.entity.RegularVoucher;
+import com.lemoo.promotion.mapper.PageMapper;
 import com.lemoo.promotion.mapper.VoucherMapper;
 import com.lemoo.promotion.repository.BaseVoucherRepository;
 import com.lemoo.promotion.service.RegularVoucherService;
 import com.lemoo.promotion.service.StoreService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Service
 public class RegularVoucherServiceImpl extends BaseVoucherService implements RegularVoucherService {
 
     private final VoucherMapper voucherMapper;
+    private final BaseVoucherRepository baseVoucherRepository;
+    private final StoreService storeService;
+    private final PageMapper pageMapper;
 
     public RegularVoucherServiceImpl(
             BaseVoucherRepository voucherRepository,
             StoreService storeService,
-            VoucherMapper voucherMapper
+            VoucherMapper voucherMapper,
+            BaseVoucherRepository baseVoucherRepository,
+            PageMapper pageMapper
     ) {
         super(voucherRepository, storeService);
         this.voucherMapper = voucherMapper;
+        this.baseVoucherRepository = baseVoucherRepository;
+        this.storeService = storeService;
+        this.pageMapper = pageMapper;
     }
 
     @Override
     public String createVoucher(RegularVoucherRequest request, String storeId, AuthenticatedAccount account) {
         return super.createVoucher(storeId, account, request);
+    }
+
+    @Override
+    public PageableResponse<RegularVoucherResponse> findAllByStoreId(String storeId, int page, int limit, AuthenticatedAccount account) {
+        storeService.verifyStore(account.getId(), storeId);
+
+        PageRequest pageRequest = PageRequest.of(page, limit, Sort.by(Sort.Direction.DESC, "updatedAt"));
+
+        Page<BaseVoucher> baseVouchers = baseVoucherRepository
+                .findAllByStoreIdAndVoucherType(storeId, VoucherType.REGULAR_VOUCHER, pageRequest);
+
+        Page<RegularVoucherResponse> regularVouchers = baseVouchers
+                .map(baseVoucher -> voucherMapper.toRegularVoucherResponse((RegularVoucher) baseVoucher));
+
+        return pageMapper.toPageableResponse(regularVouchers);
     }
 
     @Override


### PR DESCRIPTION
Implements an endpoint to retrieve all regular vouchers associated with a specific store, with pagination support.

This allows for easier management and display of vouchers within the store's administrative interface.

This pull request introduces a new feature to list all regular vouchers with pagination support. The main changes include updates to the controller, repository, service interface, and service implementation to support this functionality.

### Controller updates:
* Added a new endpoint `getAllRegularVoucher` in `RegularVoucherController` to handle GET requests for listing all regular vouchers with pagination.

### Repository updates:
* Added a method `findAllByStoreIdAndVoucherType` in `BaseVoucherRepository` to fetch vouchers by store ID and voucher type with pagination support.

### Service updates:
* Updated `RegularVoucherService` interface to include `findAllByStoreId` method for fetching paginated regular vouchers.
* Implemented the `findAllByStoreId` method in `RegularVoucherServiceImpl` to handle the business logic for fetching and mapping paginated regular vouchers.

### Other changes:
* Added necessary imports for `PageableResponse`, `Page`, and `PageRequest` in various files to support pagination. [[1]](diffhunk://#diff-b05ac4f67af7248470797aebfb58cf5a18c0b7f90f63496bdf8dcb1a69e726baR14) [[2]](diffhunk://#diff-99d66212a2b54ea58af11dbd9be622bed43c8843a833b6b43fb880bbc0f429c8R11-R12) [[3]](diffhunk://#diff-44de666df1d5d692cdaa33502b61ec85efeeebf70ca5c5851ca733ea6d67163eR11-R20) [[4]](diffhunk://#diff-b768e24f7bd910932297bee6b91a6a4e7f2f9c0fbdfcd69a81c3dd87793c32f3R14-R69)