### PR TITLE
Maps image URL to internal product SKU response

### DIFF
--- a/api/Product/src/main/java/com/lemoo/product/mapper/ProductSkuMapper.java
+++ b/api/Product/src/main/java/com/lemoo/product/mapper/ProductSkuMapper.java
@@ -21,6 +21,7 @@ public interface ProductSkuMapper {
     @Mapping(target = "originPrice", source = "price")
     ProductSkuResponse toProductSkuResponse(ProductSku sku);
 
+    @Mapping(target = "image", source = "sku.image.url")
     InternalProductSkuResponse toInternalProductSkuResponse(ProductSku sku);
 
 }


### PR DESCRIPTION
Configures the mapper to populate the image field in the InternalProductSkuResponse with the URL from the sku image. This ensures the internal representation of the product SKU includes the image URL.