### PR TITLE
Permits internal requests without authentication

### DIFF
--- a/api/Media/src/main/java/com/lemoo/media/config/SecurityConfig.java
+++ b/api/Media/src/main/java/com/lemoo/media/config/SecurityConfig.java
@@ -23,22 +23,26 @@ import org.springframework.security.web.access.AccessDeniedHandler;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-	private final JwtAuthenticationConverter jwtAuthenticationConverter;
-	private final AccessDeniedHandler accessDeniedHandler;
-	private final AuthenticationEntryPoint authenticationEntryPoint;
+    private final JwtAuthenticationConverter jwtAuthenticationConverter;
+    private final AccessDeniedHandler accessDeniedHandler;
+    private final AuthenticationEntryPoint authenticationEntryPoint;
 
-	@Bean
-	SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    @Bean
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-		http.csrf(AbstractHttpConfigurer::disable)
-				.sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-				.exceptionHandling(handler -> handler.authenticationEntryPoint(authenticationEntryPoint)
-						.accessDeniedHandler(accessDeniedHandler))
-				.authorizeHttpRequests(request -> request.anyRequest().authenticated())
-				.oauth2ResourceServer(
-						oauth -> oauth.jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter))
-								.authenticationEntryPoint(authenticationEntryPoint));
+        http.csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(handler -> handler.authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler))
+                .authorizeHttpRequests(request -> request
+                        .requestMatchers(
+                                "/internal/**"
+                        ).permitAll()
+                        .anyRequest().authenticated())
+                .oauth2ResourceServer(
+                        oauth -> oauth.jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter))
+                                .authenticationEntryPoint(authenticationEntryPoint));
 
-		return http.build();
-	}
+        return http.build();
+    }
 }


### PR DESCRIPTION
Allows unauthenticated access to endpoints under `/internal/**`. This is to enable internal services to communicate with the media service without requiring authentication.