### PR TITLE
Refactors media retrieval for performance

### DIFF
--- a/api/Media/src/main/java/com/lemoo/media/repository/MediaRepository.java
+++ b/api/Media/src/main/java/com/lemoo/media/repository/MediaRepository.java
@@ -13,8 +13,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 @Repository
 public interface MediaRepository extends MongoRepository<BaseMedia, String> {
@@ -24,7 +24,7 @@ public interface MediaRepository extends MongoRepository<BaseMedia, String> {
 
     Page<BaseMedia> findAllByStoreIdAndType(String storeId, MediaType type, Pageable pageable);
 
-    Set<BaseMedia> findAllByStoreIdAndType(String storeId, MediaType type);
+    List<BaseMedia> findAllByStoreIdAndType(String storeId, MediaType type);
 
     Optional<BaseMedia> findByStoreIdAndUserId(String storeId, String userId);
 }

--- a/api/Media/src/main/java/com/lemoo/media/service/impl/InternalMediaServiceImpl.java
+++ b/api/Media/src/main/java/com/lemoo/media/service/impl/InternalMediaServiceImpl.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -28,11 +29,11 @@ public class InternalMediaServiceImpl implements InternalMediaService {
     public Map<String, String> batchGetImageMediaUrl(Set<String> mediaIds, String storeId) {
         Map<String, String> result = new HashMap<>();
 
-        Set<BaseMedia> mediaList = mediaRepository.findAllByStoreIdAndType(storeId, MediaType.IMAGE);
+        List<BaseMedia> mediaList = mediaRepository.findAllByStoreIdAndType(storeId, MediaType.IMAGE);
 
         mediaList.forEach(media -> {
-            if (mediaIds.contains(media.getPublicId())) {
-                result.put(media.getPublicId(), media.getUrl());
+            if (mediaIds.contains(media.getId())) {
+                result.put(media.getId(), media.getUrl());
             }
         });
 

--- a/api/Product/src/main/java/com/lemoo/product/service/impl/SellerProductServiceImpl.java
+++ b/api/Product/src/main/java/com/lemoo/product/service/impl/SellerProductServiceImpl.java
@@ -79,7 +79,7 @@ public class SellerProductServiceImpl implements SellerProductService {
                 .variants(toProductVariant(request.getVariants()))
                 .smallImage(sellerProductMapper.toProductMedia(request.getSmallImage(), mediaUrls))
                 .images(request.getImages().stream()
-                        .map(sellerProductMapper::toProductMedia)
+                        .map(image -> sellerProductMapper.toProductMedia(image, mediaUrls))
                         .toList())
                 .build());
 


### PR DESCRIPTION
Changes the return type of the media retrieval method from Set to List to improve performance and maintain ordering. Also, it ensures that the correct media ID is used when retrieving media URLs. Finally, it maps the product images correctly, ensuring that the media URLs are properly associated with the product images.