### PR TITLE
Fixes typo in Kafka bootstrap server environment variable

### DIFF
--- a/api/Product-evaluation-worker/config/kafka_config.py
+++ b/api/Product-evaluation-worker/config/kafka_config.py
@@ -1,3 +1,3 @@
 import os
 
-KAFKA_BOOTSTRAP_SERVER = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9093")
+KAFKA_BOOTSTRAP_SERVER = os.getenv("KAFKA_BOOTSTRAP_SERVER", "localhost:9093")

--- a/api/Product-evaluation-worker/consumers/product_evaluation_consumer.py
+++ b/api/Product-evaluation-worker/consumers/product_evaluation_consumer.py
@@ -11,7 +11,7 @@ from utils.product_evaluation import evaluation
 def consume_product_evaluation():
     consumer = KafkaConsumer(
         'product-service.evaluation-product',
-        bootstrap_servers=os.getenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9093"),
+        bootstrap_servers=os.getenv("KAFKA_BOOTSTRAP_SERVER", "localhost:9093"),
         auto_offset_reset='earliest',
         enable_auto_commit=True,
         group_id='product-evaluation-worker-group'


### PR DESCRIPTION
Corrects the environment variable name for the Kafka bootstrap server from `KAFKA_BOOTSTRAP_SERVERS` to `KAFKA_BOOTSTRAP_SERVER` in both the configuration file and the consumer. This ensures that the application correctly retrieves the Kafka server address from the environment.