### PR TITLE
Enables store-specific notifications

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -24,7 +24,6 @@
           <entry name="$MAVEN_REPOSITORY$/org/projectlombok/lombok-mapstruct-binding/0.2.0/lombok-mapstruct-binding-0.2.0.jar" />
         </processorPath>
         <module name="Socket" />
-        <module name="Notification" />
       </profile>
       <profile name="Annotation profile for User" enabled="true">
         <sourceOutputDir name="target/generated-sources/annotations" />
@@ -59,6 +58,7 @@
         <module name="Shipping" />
         <module name="Promotion" />
         <module name="Admin" />
+        <module name="Notification" />
       </profile>
     </annotationProcessing>
   </component>

--- a/api/Notification/pom.xml
+++ b/api/Notification/pom.xml
@@ -32,6 +32,17 @@
         <spotless.version>2.43.0</spotless.version>
         <spring-cloud.version>2024.0.0</spring-cloud.version>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -92,6 +103,14 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
     </dependencies>
 

--- a/api/Notification/src/main/java/com/lemoo/notification/NotificationApplication.java
+++ b/api/Notification/src/main/java/com/lemoo/notification/NotificationApplication.java
@@ -2,10 +2,12 @@ package com.lemoo.notification;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
 
 @SpringBootApplication
 @EnableMongoAuditing
+@EnableFeignClients
 public class NotificationApplication {
 
     public static void main(String[] args) {

--- a/api/Notification/src/main/java/com/lemoo/notification/client/StoreClient.java
+++ b/api/Notification/src/main/java/com/lemoo/notification/client/StoreClient.java
@@ -1,0 +1,21 @@
+/*
+ *  StoreClient
+ *  @author: Minhhieuano
+ *  @created 12/26/2024 4:03 PM
+ * */
+
+package com.lemoo.notification.client;
+
+
+import com.lemoo.notification.dto.request.VerifyStoreRequest;
+import com.lemoo.notification.dto.response.ApiResponse;
+import jakarta.validation.Valid;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "store-service", url = "${services.store-service}/internal")
+public interface StoreClient {
+    @PostMapping("/verify")
+    ApiResponse<Boolean> verifyStore(@RequestBody @Valid VerifyStoreRequest request);
+}

--- a/api/Notification/src/main/java/com/lemoo/notification/common/constants/CustomRequestHeader.java
+++ b/api/Notification/src/main/java/com/lemoo/notification/common/constants/CustomRequestHeader.java
@@ -1,0 +1,11 @@
+/*
+ *  CustomerHeader
+ *  @author: Minhhieuano
+ *  @created 12/26/2024 1:15 AM
+ * */
+
+package com.lemoo.notification.common.constants;
+
+public class CustomRequestHeader {
+    public static final String STORE_ID = "X-Store-Id";
+}

--- a/api/Notification/src/main/java/com/lemoo/notification/common/properties/ServiceUrl.java
+++ b/api/Notification/src/main/java/com/lemoo/notification/common/properties/ServiceUrl.java
@@ -9,5 +9,5 @@ package com.lemoo.notification.common.properties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "services")
-public record ServiceUrl(String authService) {
+public record ServiceUrl(String authService, String storeService) {
 }

--- a/api/Notification/src/main/java/com/lemoo/notification/controller/StoreNotificationController.java
+++ b/api/Notification/src/main/java/com/lemoo/notification/controller/StoreNotificationController.java
@@ -7,6 +7,7 @@
 
 package com.lemoo.notification.controller;
 
+import com.lemoo.notification.common.constants.CustomRequestHeader;
 import com.lemoo.notification.dto.common.AuthenticatedAccount;
 import com.lemoo.notification.dto.response.ApiResponse;
 import com.lemoo.notification.dto.response.NotificationResponse;
@@ -14,10 +15,7 @@ import com.lemoo.notification.dto.response.PageableResponse;
 import com.lemoo.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController()
 @RequestMapping("/store")
@@ -29,8 +27,9 @@ public class StoreNotificationController {
     public ApiResponse<PageableResponse<NotificationResponse>> getAllNotification(
             @RequestParam(value = "page", required = false, defaultValue = "0") int page,
             @RequestParam(value = "limit", required = false, defaultValue = "20") int limit,
-            @AuthenticationPrincipal AuthenticatedAccount account
+            @AuthenticationPrincipal AuthenticatedAccount account,
+            @RequestHeader(CustomRequestHeader.STORE_ID) String storeId
     ) {
-        return ApiResponse.success(notificationService.getAllStoreNotification(page, limit, account));
+        return ApiResponse.success(notificationService.getAllStoreNotification(storeId, page, limit, account));
     }
 }

--- a/api/Notification/src/main/java/com/lemoo/notification/dto/request/VerifyStoreRequest.java
+++ b/api/Notification/src/main/java/com/lemoo/notification/dto/request/VerifyStoreRequest.java
@@ -1,0 +1,17 @@
+/*
+ *  VerifyStoreRequest
+ *  @author: Minhhieuano
+ *  @created 12/26/2024 10:07 AM
+ * */
+
+package com.lemoo.notification.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class VerifyStoreRequest {
+    private String accountId;
+    private String storeId;
+}

--- a/api/Notification/src/main/java/com/lemoo/notification/service/NotificationService.java
+++ b/api/Notification/src/main/java/com/lemoo/notification/service/NotificationService.java
@@ -14,7 +14,7 @@ import com.lemoo.notification.entity.Notification;
 public interface NotificationService {
     PageableResponse<NotificationResponse> getAllNotification(int page, int limit, AuthenticatedAccount account);
 
-    PageableResponse<NotificationResponse> getAllStoreNotification(int page, int limit, AuthenticatedAccount account);
+    PageableResponse<NotificationResponse> getAllStoreNotification(String storeId, int page, int limit, AuthenticatedAccount account);
 
     void saveNotification(Notification notification);
 }

--- a/api/Notification/src/main/java/com/lemoo/notification/service/StoreService.java
+++ b/api/Notification/src/main/java/com/lemoo/notification/service/StoreService.java
@@ -1,0 +1,12 @@
+/*
+ *  StoreService
+ *  @author: Minhhieuano
+ *  @created 12/15/2024 9:55 PM
+ * */
+
+package com.lemoo.notification.service;
+
+public interface StoreService {
+
+    void verifyStore(String accountId, String storeId);
+}

--- a/api/Notification/src/main/java/com/lemoo/notification/service/impl/StoreServiceImpl.java
+++ b/api/Notification/src/main/java/com/lemoo/notification/service/impl/StoreServiceImpl.java
@@ -1,0 +1,53 @@
+/*
+ *  StoreServiceImpl
+ *  @author: Minhhieuano
+ *  @created 1/2/2025 12:24 AM
+ * */
+
+
+package com.lemoo.notification.service.impl;
+
+import com.lemoo.notification.client.StoreClient;
+import com.lemoo.notification.dto.request.VerifyStoreRequest;
+import com.lemoo.notification.exception.ForbiddenException;
+import com.lemoo.notification.service.StoreService;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RBucket;
+import org.redisson.api.RedissonClient;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class StoreServiceImpl implements StoreService {
+
+    private final StoreClient storeClient;
+    private final RedissonClient redisson;
+
+    @Override
+    public void verifyStore(String accountId, String storeId) {
+        RBucket<String> bucket = redisson.getBucket(generateStoreOwnerVerifyKey(storeId));
+        String ownerId = bucket.get();
+        if (ownerId != null && ownerId.equals(accountId)) return;
+        boolean isStoreOwner = storeClient.verifyStore(new VerifyStoreRequest(accountId, storeId)).getData();
+        if (!isStoreOwner) throw new ForbiddenException("Only store owner can be modify product");
+        saveStoreOwnerToCacheAsync(accountId, storeId);
+    }
+
+    @Async
+    protected void saveStoreOwnerToCacheAsync(String accountId, String storeId) {
+        String key = generateStoreOwnerVerifyKey(storeId);
+        RBucket<String> bucket = redisson.getBucket(key);
+        try {
+            bucket.set(accountId, Duration.ofMinutes(30));
+        } catch (Exception ex) {
+            throw new RuntimeException("Save store verify to cache failed with key: " + key);
+        }
+    }
+
+    private String generateStoreOwnerVerifyKey(String storeId) {
+        return "store:" + storeId + ":owner";
+    }
+}

--- a/api/Notification/src/main/resources/application.yml
+++ b/api/Notification/src/main/resources/application.yml
@@ -32,6 +32,6 @@ server:
     context-path: /notifications
 services:
   auth-service: ${AUTH_SERVICE_URL:http://localhost:8082/auth}
-
+  store-service: ${STORE_SERVICE_URL:http://localhost:8088/store}
 cache:
   redis_url: ${REDIS_URL}


### PR DESCRIPTION
Adds functionality to retrieve notifications specific to a store.

This change introduces a new `StoreService` to verify store ownership via Feign client and caches the verification result in Redis for 30 minutes, preventing unauthorized access to store notifications.

It also modifies the `StoreNotificationController` to receive the store ID from the request header and passes it to the `NotificationService`. The `NotificationService` then retrieves notifications based on the store ID.