### PR TITLE
Allows updating default shipping address

### DIFF
--- a/api/Shipping/src/main/java/com/lemoo/shipping/controller/BuyerShippingController.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/controller/BuyerShippingController.java
@@ -41,4 +41,13 @@ public class BuyerShippingController {
         return ApiResponse.success(shippingAddressService.createShippingAddress(account, request));
     }
 
+    @PutMapping("{addressId}")
+    public ApiResponse<Boolean> updateDefaultAddress(
+            @PathVariable("addressId") String addressId,
+            @AuthenticationPrincipal AuthenticatedAccount account
+    ) {
+        shippingAddressService.updateDefaultAddress(account, addressId);
+        return ApiResponse.success(true);
+    }
+
 }

--- a/api/Shipping/src/main/java/com/lemoo/shipping/repository/ShippingAddressRepository.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/repository/ShippingAddressRepository.java
@@ -23,4 +23,6 @@ public interface ShippingAddressRepository extends MongoRepository<ShippingAddre
     Page<ShippingAddress> findAllByUserId(String userId, Pageable pageable);
 
     Optional<ShippingAddress> findByIdAndUserId(String id, String userId);
+
+    Optional<ShippingAddress> findByUserIdAndIsDefault(String userId, Boolean isDefault);
 }

--- a/api/Shipping/src/main/java/com/lemoo/shipping/service/ShippingAddressService.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/service/ShippingAddressService.java
@@ -18,4 +18,5 @@ public interface ShippingAddressService {
 
     PageableResponse<ShippingAddressResponse> getAllShipAddress(AuthenticatedAccount account, int page, int limit);
 
+    void updateDefaultAddress(AuthenticatedAccount account, String addressId);
 }

--- a/api/Shipping/src/main/java/com/lemoo/shipping/service/impl/ShippingAddressServiceImpl.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/service/impl/ShippingAddressServiceImpl.java
@@ -12,6 +12,7 @@ import com.lemoo.shipping.dto.request.ShippingAddressRequest;
 import com.lemoo.shipping.dto.response.PageableResponse;
 import com.lemoo.shipping.dto.response.ShippingAddressResponse;
 import com.lemoo.shipping.entity.ShippingAddress;
+import com.lemoo.shipping.exception.NotfoundException;
 import com.lemoo.shipping.mapper.PageMapper;
 import com.lemoo.shipping.mapper.ShippingAddressMapper;
 import com.lemoo.shipping.repository.ShippingAddressRepository;
@@ -45,5 +46,25 @@ public class ShippingAddressServiceImpl implements ShippingAddressService {
         PageRequest request = PageRequest.of(page, limit);
         Page<?> shippingAddresses = shippingAddressRepository.findAllByUserId(account.getUserId(), request);
         return pageMapper.toPageableResponse(shippingAddresses);
+    }
+
+    @Override
+    public void updateDefaultAddress(AuthenticatedAccount account, String addressId) {
+        ShippingAddress address = shippingAddressRepository.findById(addressId)
+                .orElseThrow(() -> new NotfoundException("Address not found"));
+
+        ShippingAddress oldDefaultAddress = shippingAddressRepository.
+                findByUserIdAndIsDefault(account.getUserId(), true)
+                .orElse(null);
+
+        if (oldDefaultAddress != null) {
+            oldDefaultAddress.setIsDefault(false);
+            shippingAddressRepository.save(oldDefaultAddress);
+        }
+
+        address.setIsDefault(true);
+
+        shippingAddressRepository.save(address);
+
     }
 }


### PR DESCRIPTION
Enables users to update their default shipping address.

This change introduces an endpoint that allows a user to designate a specific shipping address as their default. The previous default address, if any, will be updated to no longer be the default.

This pull request introduces functionality to update the default shipping address for a user. The changes span multiple files, adding new methods and modifying existing ones to support this feature.

Key changes include:

### Controller Updates:
* [`BuyerShippingController.java`](diffhunk://#diff-3f8f391d15c9e30ba3b08a3b49c3903c105595faba2f0a4c110327e059663cf2R44-R52): Added a new endpoint to update the default shipping address.

### Repository Updates:
* [`ShippingAddressRepository.java`](diffhunk://#diff-f00d49394b4017f9ecbe26d6a5a48de652df12f883112a4dbe60a958d93bd448R26-R27): Added a method to find the default shipping address by user ID.

### Service Interface Updates:
* [`ShippingAddressService.java`](diffhunk://#diff-f112556549954394dec7277440f379a2552754fd73f64ef4e8392da0a32a8f73R21): Added a method signature for updating the default shipping address.

### Service Implementation Updates:
* [`ShippingAddressServiceImpl.java`](diffhunk://#diff-3d45818f64c0393a5e51701e9a58b904b3837db71f59813da7c93b62c93d1d01R50-R69): Implemented the logic to update the default shipping address, including handling cases where an old default address exists.
* [`ShippingAddressServiceImpl.java`](diffhunk://#diff-3d45818f64c0393a5e51701e9a58b904b3837db71f59813da7c93b62c93d1d01R15): Added an import for `NotfoundException`.