### PR TITLE
Implement OTP notification feature for account creation with email template

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -13,7 +13,7 @@
       </jdbc-additional-properties>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
-    <data-source source="LOCAL" name="165.227.255.158:5432" uuid="f97a26f7-5b33-4870-a369-2936b3fbb30f">
+    <data-source source="LOCAL" name="auth-db" uuid="f97a26f7-5b33-4870-a369-2936b3fbb30f">
       <driver-ref>postgresql</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>org.postgresql.Driver</jdbc-driver>

--- a/api/Auth/src/main/java/com/lemoo/auth/event/producer/AccountProducer.java
+++ b/api/Auth/src/main/java/com/lemoo/auth/event/producer/AccountProducer.java
@@ -14,9 +14,9 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class AccountProducer {
-	private final KafkaTemplate<String, Object> accountTemplate;
+    private final KafkaTemplate<String, Object> accountTemplate;
 
-	public void sendAccountCreationOtp(AccountCreationOtpEvent event) {
-		accountTemplate.send("account_creation_otp", event);
-	}
+    public void sendAccountCreationOtp(AccountCreationOtpEvent event) {
+        accountTemplate.send("auth-service.account.new.send-otp", event);
+    }
 }

--- a/api/Notification/pom.xml
+++ b/api/Notification/pom.xml
@@ -112,6 +112,18 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.thymeleaf.extras</groupId>
+            <artifactId>thymeleaf-extras-springsecurity6</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api/Notification/src/main/java/com/lemoo/notification/config/ThymeleafConfig.java
+++ b/api/Notification/src/main/java/com/lemoo/notification/config/ThymeleafConfig.java
@@ -1,0 +1,26 @@
+/*
+ *  ThymeleafConfig
+ *  @author: Minhhieuano
+ *  @created 3/24/2025 3:46 PM
+ * */
+
+
+package com.lemoo.notification.config;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+@Configuration
+@RequiredArgsConstructor
+public class ThymeleafConfig {
+    private final SpringTemplateEngine springTemplateEngine;
+
+    @Bean
+    public TemplateEngine thymeleafTemplateEngine() {
+        return springTemplateEngine;
+    }
+}

--- a/api/Notification/src/main/java/com/lemoo/notification/event/consumer/AuthConsumer.java
+++ b/api/Notification/src/main/java/com/lemoo/notification/event/consumer/AuthConsumer.java
@@ -1,0 +1,26 @@
+/*
+ *  AuthConsumer
+ *  @author: Minhhieuano
+ *  @created 3/24/2025 4:17 PM
+ * */
+
+
+package com.lemoo.notification.event.consumer;
+
+
+import com.lemoo.notification.event.model.AccountCreationOtpEvent;
+import com.lemoo.notification.service.OtpNotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuthConsumer {
+    private final OtpNotificationService otpNotificationService;
+
+    @KafkaListener(topics = "auth-service.account.new.send-otp", groupId = "${spring.kafka.consumer.group-id}")
+    public void sendAccountCreationOtp(AccountCreationOtpEvent event) {
+        otpNotificationService.sendAccountCreationOtp(event.getEmail(), event.getOtp());
+    }
+}

--- a/api/Notification/src/main/java/com/lemoo/notification/event/model/AccountCreationOtpEvent.java
+++ b/api/Notification/src/main/java/com/lemoo/notification/event/model/AccountCreationOtpEvent.java
@@ -1,0 +1,22 @@
+/*
+ *  AccountCreationOtpEvnt
+ *  @author: Minhhieuano
+ *  @created 12/25/2024 12:52 PM
+ * */
+
+package com.lemoo.notification.event.model;
+
+import lombok.*;
+
+@Data
+@Builder
+@EqualsAndHashCode(callSuper = true)
+@AllArgsConstructor
+@NoArgsConstructor
+public class AccountCreationOtpEvent extends Event {
+
+    private String email;
+    private String otp;
+
+
+}

--- a/api/Notification/src/main/java/com/lemoo/notification/service/OtpNotificationService.java
+++ b/api/Notification/src/main/java/com/lemoo/notification/service/OtpNotificationService.java
@@ -1,0 +1,11 @@
+/*
+ *  OtpNotificationService
+ *  @author: Minhhieuano
+ *  @created 3/24/2025 3:39 PM
+ * */
+
+package com.lemoo.notification.service;
+
+public interface OtpNotificationService {
+    void sendAccountCreationOtp(String email, String otp);
+}

--- a/api/Notification/src/main/java/com/lemoo/notification/service/impl/OtpNotificationServiceImpl.java
+++ b/api/Notification/src/main/java/com/lemoo/notification/service/impl/OtpNotificationServiceImpl.java
@@ -1,0 +1,43 @@
+/*
+ *  OtpNotificationServiceImpl
+ *  @author: Minhhieuano
+ *  @created 3/24/2025 3:40 PM
+ * */
+
+
+package com.lemoo.notification.service.impl;
+
+import com.lemoo.notification.service.OtpNotificationService;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class OtpNotificationServiceImpl implements OtpNotificationService {
+
+    private final JavaMailSender javaMailSender;
+    private final TemplateEngine templateEngine;
+
+    @Override
+    @SneakyThrows
+    public void sendAccountCreationOtp(String email, String otp) {
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true);
+
+        helper.setTo(email);
+        helper.setSubject("Complete Your Lemoo Account Setup with This OTP");
+
+        Context context = new Context();
+        context.setVariables(Map.of("otpCode", otp, "userEmail", email));
+        helper.setText(templateEngine.process("account-creation", context), true);
+        javaMailSender.send(mimeMessage);
+    }
+}

--- a/api/Notification/src/main/resources/application.yml
+++ b/api/Notification/src/main/resources/application.yml
@@ -26,6 +26,22 @@ spring:
       auto-offset-reset: earliest
       properties:
         spring.json.trusted.packages: '*'
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USER}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          writetimeout: 10000
+          connectiontimeout: 10000
+          timeout: 10000
+          auth: true
+          starttls:
+            enable: true
+            required: true
+    default-encoding: UTF-8
 server:
   port: 4006
   servlet:

--- a/api/Notification/src/main/resources/templates/account-creation.html
+++ b/api/Notification/src/main/resources/templates/account-creation.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <title>Lemoo Account Verification</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f4f4f4;
+            margin: 0;
+            padding: 0;
+        }
+
+        .email-container {
+            max-width: 600px;
+            margin: 20px auto;
+            background-color: #ffffff;
+            border-radius: 8px;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+            overflow: hidden;
+        }
+
+        .header {
+            background-color: #007BFF;
+            color: white;
+            text-align: center;
+            padding: 20px;
+        }
+
+        .content {
+            padding: 20px;
+            text-align: center;
+        }
+
+        .otp-code {
+            font-size: 36px;
+            font-weight: bold;
+            color: #007BFF;
+            background-color: #e9f5ff;
+            display: inline-block;
+            padding: 15px 30px;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            margin: 20px 0;
+        }
+
+        .footer {
+            background-color: #f1f1f1;
+            text-align: center;
+            padding: 10px;
+            font-size: 12px;
+            color: #555;
+        }
+
+        a {
+            color: #007BFF;
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+<div class="email-container">
+    <div class="header">
+        <h1>Welcome to Lemoo</h1>
+        <p>Your One-Time Password (OTP) for account verification</p>
+    </div>
+    <div class="content">
+        <p>Hello, <span th:text="${userEmail}"></span></p>
+        <p>Thank you for signing up with Lemoo! To complete your account verification, please use the OTP provided
+            below:</p>
+        <div class="otp-code" th:text="${otpCode}">123456</div>
+        <p>This OTP is valid for <strong>5 minutes</strong>. Please do not share it with anyone for security reasons.
+        </p>
+        <p>If you did not request this code, please contact our support team immediately at <a
+                href="mailto:support@lemoo.com">support@lemoo.com</a>.</p>
+        <p>Best regards,<br>The Lemoo Team</p>
+    </div>
+    <div class="footer">
+        &copy; 2024 Lemoo. All rights reserved.<br>
+        <a href="https://www.lemoo.com/terms">Terms of Service</a> | <a href="https://www.lemoo.com/privacy">Privacy
+        Policy</a>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
This pull request introduces several changes to the notification service, including the addition of new dependencies, configurations, and classes to support OTP notifications via email. The most important changes are grouped by theme and summarized below:

### Configuration and Dependencies:

* Added `spring-boot-starter-mail`, `spring-boot-starter-thymeleaf`, and `thymeleaf-extras-springsecurity6` dependencies to `api/Notification/pom.xml`.
* Updated `application.yml` to include email server configurations for sending OTP emails.

### New Classes and Services:

* Introduced `ThymeleafConfig` class to configure the Thymeleaf template engine.
* Added `AuthConsumer` class to listen for OTP events and trigger the OTP notification service.
* Created `AccountCreationOtpEvent` model class to represent OTP events.
* Defined `OtpNotificationService` interface and its implementation `OtpNotificationServiceImpl` to handle sending OTP emails. [[1]](diffhunk://#diff-de714b08cde606ab222f19b4cfb4d5e4da51714922388ec5c78bf5ad2ba040d8R1-R11) [[2]](diffhunk://#diff-dfac28f98e4ace29f47adca60e93208f1ca307daf60b677665c9cc1861defab2R1-R43)

### Template:

* Added `account-creation.html` template for OTP email content.

### Minor Changes:

* Updated the Kafka topic name in `AccountProducer` to reflect the new naming convention.
* Renamed the data source in `.idea/dataSources.xml` for clarity.