### PR TITLE
Add get all store order controller

### DIFF
--- a/api/Order_v2/src/main/java/com/lemoo/order_v2/common/constants/CustomRequestHeader.java
+++ b/api/Order_v2/src/main/java/com/lemoo/order_v2/common/constants/CustomRequestHeader.java
@@ -1,0 +1,12 @@
+/*
+ *  CustomerHeader
+ *  @author: Minhhieuano
+ *  @created 12/26/2024 1:15 AM
+ * */
+
+package com.lemoo.order_v2.common.constants;
+
+public class CustomRequestHeader {
+    public static final String STORE_ID = "X-Store-Id";
+    public static final String CHANNEL_ID = "X-Channel-Id";
+}

--- a/api/Order_v2/src/main/java/com/lemoo/order_v2/controller/SellerOrderController.java
+++ b/api/Order_v2/src/main/java/com/lemoo/order_v2/controller/SellerOrderController.java
@@ -7,13 +7,29 @@
 
 package com.lemoo.order_v2.controller;
 
+import com.lemoo.order_v2.common.constants.CustomRequestHeader;
+import com.lemoo.order_v2.dto.common.AuthenticatedAccount;
+import com.lemoo.order_v2.dto.response.ApiResponse;
+import com.lemoo.order_v2.dto.response.PageableResponse;
+import com.lemoo.order_v2.dto.response.SellerOrderResponse;
+import com.lemoo.order_v2.service.SellerOrderService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/orders/seller")
 @RequiredArgsConstructor
 public class SellerOrderController {
+    private final SellerOrderService sellerOrderService;
 
+    @GetMapping
+    public ApiResponse<PageableResponse<SellerOrderResponse>> getAllStoreOrder(
+            @RequestParam(value = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(value = "limit", required = false, defaultValue = "10") int limit,
+            @AuthenticationPrincipal AuthenticatedAccount account,
+            @RequestHeader(CustomRequestHeader.STORE_ID) String storeId
+    ) {
+        return ApiResponse.success(sellerOrderService.getAllOrderByStoreId(storeId, page, limit, account));
+    }
 }

--- a/api/Order_v2/src/main/java/com/lemoo/order_v2/service/SellerOrderService.java
+++ b/api/Order_v2/src/main/java/com/lemoo/order_v2/service/SellerOrderService.java
@@ -8,10 +8,10 @@ package com.lemoo.order_v2.service;
 
 import com.lemoo.order_v2.dto.common.AuthenticatedAccount;
 import com.lemoo.order_v2.dto.response.PageableResponse;
-import com.lemoo.order_v2.dto.response.SellerOrderItemResponse;
+import com.lemoo.order_v2.dto.response.SellerOrderResponse;
 
 public interface SellerOrderService {
-    PageableResponse<SellerOrderItemResponse> getAllOrderByStoreId(
+    PageableResponse<SellerOrderResponse> getAllOrderByStoreId(
             String storeId,
             int page,
             int limit,

--- a/api/Order_v2/src/main/java/com/lemoo/order_v2/service/impl/SellerOrderServiceImpl.java
+++ b/api/Order_v2/src/main/java/com/lemoo/order_v2/service/impl/SellerOrderServiceImpl.java
@@ -9,7 +9,6 @@ package com.lemoo.order_v2.service.impl;
 
 import com.lemoo.order_v2.dto.common.AuthenticatedAccount;
 import com.lemoo.order_v2.dto.response.PageableResponse;
-import com.lemoo.order_v2.dto.response.SellerOrderItemResponse;
 import com.lemoo.order_v2.dto.response.SellerOrderResponse;
 import com.lemoo.order_v2.entity.Order;
 import com.lemoo.order_v2.mapper.PageMapper;
@@ -33,7 +32,7 @@ public class SellerOrderServiceImpl implements SellerOrderService {
     private final PageMapper pageMapper;
 
     @Override
-    public PageableResponse<SellerOrderItemResponse> getAllOrderByStoreId(String storeId, int page, int limit, AuthenticatedAccount account) {
+    public PageableResponse<SellerOrderResponse> getAllOrderByStoreId(String storeId, int page, int limit, AuthenticatedAccount account) {
         storeService.verifyStore(account.getId(), storeId);
 
         PageRequest request = PageRequest.of(page, limit, Sort.Direction.ASC, "createdAt");


### PR DESCRIPTION
This pull request introduces several changes to the `Order_v2` API, primarily focusing on the addition of a new custom request header and modifications to the `SellerOrderController` and related services. The most important changes include the creation of a new `CustomRequestHeader` class, updates to the `SellerOrderController` to handle new endpoints, and adjustments to the `SellerOrderService` and its implementation.

### New Features:
* [`api/Order_v2/src/main/java/com/lemoo/order_v2/common/constants/CustomRequestHeader.java`](diffhunk://#diff-0566aeb7bbffb2944a7707a1b77c1728a7a578a91bb41026fa56bcdcc5703cb2R1-R12): Added a new `CustomRequestHeader` class with constants for `STORE_ID` and `CHANNEL_ID`.

### Controller Updates:
* [`api/Order_v2/src/main/java/com/lemoo/order_v2/controller/SellerOrderController.java`](diffhunk://#diff-6bf8b5fb609bbeec4f694a4b255b323cb1fdafe827be7e1bb28f7fc0fbf15e2bR10-R34): Updated the `SellerOrderController` to include new imports, a new `SellerOrderService` dependency, and a new `getAllStoreOrder` endpoint to handle GET requests with pagination and custom headers.

### Service Updates:
* [`api/Order_v2/src/main/java/com/lemoo/order_v2/service/SellerOrderService.java`](diffhunk://#diff-e175be4d45a3644926b576f1e4d4590d08df8304d5533cb891569723cdc42d44L11-R14): Changed the return type of `getAllOrderByStoreId` from `SellerOrderItemResponse` to `SellerOrderResponse`.
* [`api/Order_v2/src/main/java/com/lemoo/order_v2/service/impl/SellerOrderServiceImpl.java`](diffhunk://#diff-fce24c0ff41b2f3633e5ef8a8fe47fe35564d111e8c66cd3fcb9158016950060L36-R35): Updated the implementation of `getAllOrderByStoreId` to match the new return type and ensure store verification.