### PR TITLE
Add status to seller order response

### DIFF
--- a/api/Order_v2/src/main/java/com/lemoo/order_v2/dto/response/SellerOrderResponse.java
+++ b/api/Order_v2/src/main/java/com/lemoo/order_v2/dto/response/SellerOrderResponse.java
@@ -7,6 +7,7 @@
 
 package com.lemoo.order_v2.dto.response;
 
+import com.lemoo.order_v2.common.enums.OrderStatus;
 import com.lemoo.order_v2.common.enums.PaymentMethod;
 import lombok.Builder;
 import lombok.Data;
@@ -19,10 +20,12 @@ import java.util.Set;
 @Builder
 public class SellerOrderResponse {
     private String id;
-    
+
     private PaymentMethod paymentMethod;
 
     private LocalDateTime orderDate;
+
+    private OrderStatus status;
 
     @Builder.Default
     private Set<String> vouchers = new HashSet<>();

--- a/api/Order_v2/src/main/java/com/lemoo/order_v2/mapper/SellerOrderMapper.java
+++ b/api/Order_v2/src/main/java/com/lemoo/order_v2/mapper/SellerOrderMapper.java
@@ -34,6 +34,7 @@ public abstract class SellerOrderMapper {
                 .orderDate(order.getCreatedAt())
                 .vouchers(order.getVouchers())
                 .items(orderItems)
+                .status(order.getStatus())
                 .build();
     }
 


### PR DESCRIPTION
This pull request includes changes to the `SellerOrderResponse` class and its related mapper to add the order status field. The most important changes include the addition of the `OrderStatus` import, the new `status` field in the `SellerOrderResponse` class, and the mapping of this status field in the `SellerOrderMapper` class.

Changes to `SellerOrderResponse`:

* [`api/Order_v2/src/main/java/com/lemoo/order_v2/dto/response/SellerOrderResponse.java`](diffhunk://#diff-b80358bd4d354674d31be0f0cc61cf6d15fb614e67474adf0dfbef0579dbde11R10): Added import for `OrderStatus` enum.
* [`api/Order_v2/src/main/java/com/lemoo/order_v2/dto/response/SellerOrderResponse.java`](diffhunk://#diff-b80358bd4d354674d31be0f0cc61cf6d15fb614e67474adf0dfbef0579dbde11R28-R29): Added `status` field to `SellerOrderResponse` class.

Changes to `SellerOrderMapper`:

* [`api/Order_v2/src/main/java/com/lemoo/order_v2/mapper/SellerOrderMapper.java`](diffhunk://#diff-721d4360ce4cee0295e9e30290d3459a075d0dde982c21465819886200b7220eR37): Added mapping for `status` field in `toOrderResponse` method.