### PR TITLE
Add status to seller order response

### DIFF
--- a/api/Order_v2/src/main/java/com/lemoo/order_v2/dto/response/SellerOrderResponse.java
+++ b/api/Order_v2/src/main/java/com/lemoo/order_v2/dto/response/SellerOrderResponse.java
@@ -7,6 +7,7 @@
 
 package com.lemoo.order_v2.dto.response;
 
+import com.lemoo.order_v2.common.enums.OrderStatus;
 import com.lemoo.order_v2.common.enums.PaymentMethod;
 import lombok.Builder;
 import lombok.Data;
@@ -19,10 +20,12 @@ import java.util.Set;
 @Builder
 public class SellerOrderResponse {
     private String id;
-    
+
     private PaymentMethod paymentMethod;
 
     private LocalDateTime orderDate;
+
+    private OrderStatus status;
 
     @Builder.Default
     private Set<String> vouchers = new HashSet<>();

--- a/api/Order_v2/src/main/java/com/lemoo/order_v2/mapper/SellerOrderMapper.java
+++ b/api/Order_v2/src/main/java/com/lemoo/order_v2/mapper/SellerOrderMapper.java
@@ -34,6 +34,7 @@ public abstract class SellerOrderMapper {
                 .orderDate(order.getCreatedAt())
                 .vouchers(order.getVouchers())
                 .items(orderItems)
+                .status(order.getStatus())
                 .build();
     }
 


### PR DESCRIPTION
This pull request includes changes to the `SellerOrderResponse` class and its corresponding mapper to incorporate the order status. The most important changes include adding the `OrderStatus` field to the `SellerOrderResponse` class and updating the mapper to set this new field.

Changes to `SellerOrderResponse` class:

* [`api/Order_v2/src/main/java/com/lemoo/order_v2/dto/response/SellerOrderResponse.java`](diffhunk://#diff-b80358bd4d354674d31be0f0cc61cf6d15fb614e67474adf0dfbef0579dbde11R10): Added `OrderStatus` import and a new field `status` to the `SellerOrderResponse` class. [[1]](diffhunk://#diff-b80358bd4d354674d31be0f0cc61cf6d15fb614e67474adf0dfbef0579dbde11R10) [[2]](diffhunk://#diff-b80358bd4d354674d31be0f0cc61cf6d15fb614e67474adf0dfbef0579dbde11R28-R29)

Changes to mapper:

* [`api/Order_v2/src/main/java/com/lemoo/order_v2/mapper/SellerOrderMapper.java`](diffhunk://#diff-721d4360ce4cee0295e9e30290d3459a075d0dde982c21465819886200b7220eR37): Updated the `toOrderResponse` method to set the `status` field in `SellerOrderResponse`.