### PR TITLE
Renames availableStock to reserveStock

### DIFF
--- a/api/Product/src/main/java/com/lemoo/product/domain/ProductSkuEvaluation.java
+++ b/api/Product/src/main/java/com/lemoo/product/domain/ProductSkuEvaluation.java
@@ -22,7 +22,7 @@ public class ProductSkuEvaluation {
     private LocalDateTime specialFromDate;
     private LocalDateTime specialToDate;
     private Long stock;
-    private Long availableStock;
+    private Long reserveStock;
     private Double packageWidth; // cm
     private Double packageHeight; // cm
     private Double packageLength; // cm

--- a/api/Product/src/main/java/com/lemoo/product/mapper/ProductSkuMapper.java
+++ b/api/Product/src/main/java/com/lemoo/product/mapper/ProductSkuMapper.java
@@ -22,7 +22,7 @@ public interface ProductSkuMapper {
     ProductSkuResponse toProductSkuResponse(ProductSku sku);
 
     @Mapping(target = "image", source = "sku.image.url")
-    @Mapping(target = "stock", source = "sku.availableStock")
+    @Mapping(target = "stock", source = "sku.reserveStock")
     InternalProductSkuResponse toInternalProductSkuResponse(ProductSku sku);
 
 }


### PR DESCRIPTION
Updates the `ProductSkuEvaluation` entity and `ProductSkuMapper` to use `reserveStock` instead of `availableStock`.

This change reflects a more accurate representation of the stock reservation logic.