### PR TITLE
Updates Kafka topic for shipping order creation

### DIFF
--- a/api/Shipping/src/main/java/com/lemoo/shipping/event/consumer/OrderConsumer.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/event/consumer/OrderConsumer.java
@@ -19,7 +19,7 @@ public class OrderConsumer {
 
     private final ShippingService shippingService;
 
-    @KafkaListener(topics = "shipping-service.shipping.create.failed", groupId = "${spring.kafka.consumer.group-id}")
+    @KafkaListener(topics = "order-service.shipping.create", groupId = "${spring.kafka.consumer.group-id}")
     public void createShippingOrder(NewShippingOrderEvent event) {
         shippingService.createShippingOrder(
                 event.getOrderId(),


### PR DESCRIPTION
Updates the Kafka topic that the shipping service listens to for new shipping order creation events. The topic is changed from "shipping-service.shipping.create.failed" to "order-service.shipping.create" to align with the event publishing service.