### PR TITLE
Refactors shipping order item dimensions to Integer

### DIFF
--- a/api/Shipping/src/main/java/com/lemoo/shipping/dto/common/ShippingOrderItem.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/dto/common/ShippingOrderItem.java
@@ -16,8 +16,8 @@ public class ShippingOrderItem {
     private String name;
     private String code;
     private Integer quantity;
-    private Double length;
-    private Double width;
-    private Double weight;
-    private Double height;
+    private Integer length;
+    private Integer width;
+    private Integer weight;
+    private Integer height;
 }

--- a/api/Shipping/src/main/java/com/lemoo/shipping/service/impl/ShippingServiceImpl.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/service/impl/ShippingServiceImpl.java
@@ -54,21 +54,21 @@ public class ShippingServiceImpl implements ShippingService {
                 .to_address(shippingAddress.getAddress().getProvince().getName())
                 .to_ward_code(shippingAddress.getAddress().getWard().getCode())
                 .to_district_name(shippingAddress.getAddress().getDistrict().getName())
-                .name("Lemoo-test")
+                .name("Order number: " + orderId)
                 .quantity(skus.values().stream().mapToInt(Integer::intValue).sum())
                 .items(skuResponses.stream().map(sku ->
                         ShippingOrderItem.builder()
                                 .code(sku.getSkuCode())
                                 .name(sku.getName())
                                 .quantity(skus.get(sku.getSkuCode()))
-                                .length(sku.getPackageLength())
-                                .height(sku.getPackageHeight())
-                                .width(sku.getPackageWidth())
-                                .weight(sku.getPackageWeight())
+                                .length((int) Math.ceil(sku.getPackageLength()))
+                                .height((int) Math.ceil(sku.getPackageHeight()))
+                                .width((int) Math.ceil(sku.getPackageWidth()))
+                                .weight((int) Math.ceil(sku.getPackageWeight()))
                                 .build()
                 ).toList())
                 .build();
-        
+
         ghnClient.createShippingOrder(shippingOrderRequest);
     }
 }


### PR DESCRIPTION
Updates the shipping order item dimensions (length, width, height, weight) to use Integer instead of Double to align with the GHN API requirements.

Sets the shipping order name to include the order ID for better identification.

Rounds up double values to the nearest integer value.