### PR TITLE
Creates shipping order and saves to DB

### DIFF
--- a/api/Shipping/src/main/java/com/lemoo/shipping/client/GhnClient.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/client/GhnClient.java
@@ -10,6 +10,7 @@ package com.lemoo.shipping.client;
 import com.lemoo.shipping.config.GhnRequestInterceptor;
 import com.lemoo.shipping.dto.request.NewShippingOrderRequest;
 import com.lemoo.shipping.dto.response.GhnApiResponse;
+import com.lemoo.shipping.dto.response.GhnShippingOrderResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,7 +28,7 @@ import java.util.List;
 public interface GhnClient {
 
     @PostMapping("/v2/shipping-order/create")
-    void createShippingOrder(@RequestBody NewShippingOrderRequest request);
+    GhnShippingOrderResponse createShippingOrder(@RequestBody NewShippingOrderRequest request);
 
     @GetMapping("/master-data/province")
     GhnApiResponse<List<HashMap<Object, Object>>> getProvince();

--- a/api/Shipping/src/main/java/com/lemoo/shipping/dto/response/GhnShippingOrderResponse.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/dto/response/GhnShippingOrderResponse.java
@@ -1,0 +1,61 @@
+/*
+ *  GhnShippingOrderResponse
+ *  @author: pc
+ *  @created 4/14/2025 11:36 PM
+ * */
+
+
+package com.lemoo.shipping.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GhnShippingOrderResponse {
+    private int code;
+    private String code_message_value;
+    private ResponseData data;
+    private String message;
+    private String message_display;
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ResponseData {
+        private String order_code;
+        private String sort_code;
+        private String trans_type;
+        private String ward_encode;
+        private String district_encode;
+        private Fee fee;
+        private int total_fee;
+        private String expected_delivery_time;
+        private String operation_partner;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Fee {
+        private int main_service;
+        private int insurance;
+        private int cod_fee;
+        private int station_do;
+        private int station_pu;
+        private int return_fee;
+        private int r2s;
+        private int return_again;
+        private int coupon;
+        private int document_return;
+        private int double_check;
+        private int double_check_deliver;
+        private int pick_remote_areas_fee;
+        private int deliver_remote_areas_fee;
+        private int pick_remote_areas_fee_return;
+        private int deliver_remote_areas_fee_return;
+        private int cod_failed_fee;
+    }
+}

--- a/api/Shipping/src/main/java/com/lemoo/shipping/entity/ShippingOrder.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/entity/ShippingOrder.java
@@ -1,0 +1,27 @@
+/*
+ *  ShippingOrder
+ *  @author: pc
+ *  @created 4/14/2025 4:00 PM
+ * */
+
+
+package com.lemoo.shipping.entity;
+
+import lombok.*;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+@Document
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ShippingOrder extends BaseEntity {
+    private String shippingOrderCode;
+    private Long totalFee;
+    private LocalDateTime expectedDeliveryTime;
+    private String orderId;
+    private String userId;
+}

--- a/api/Shipping/src/main/java/com/lemoo/shipping/mapper/ShippingOrderMapper.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/mapper/ShippingOrderMapper.java
@@ -1,0 +1,20 @@
+/*
+ *  ShippingOrderMapper
+ *  @author: pc
+ *  @created 4/14/2025 11:38 PM
+ * */
+
+package com.lemoo.shipping.mapper;
+
+import com.lemoo.shipping.dto.response.GhnShippingOrderResponse;
+import com.lemoo.shipping.entity.ShippingOrder;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper
+public interface ShippingOrderMapper {
+    @Mapping(source = "order_code", target = "shippingOrderCode")
+    @Mapping(source = "total_fee", target = "totalFee")
+    @Mapping(target = "expectedDeliveryTime", ignore = true)
+    ShippingOrder toShippingOrder(GhnShippingOrderResponse ghnShippingOrderResponse);
+}

--- a/api/Shipping/src/main/java/com/lemoo/shipping/repository/ShippingOrderRepository.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/repository/ShippingOrderRepository.java
@@ -1,0 +1,16 @@
+/*
+ *  ShippingOrderRepository
+ *  @author: pc
+ *  @created 4/15/2025 12:09 AM
+ * */
+
+package com.lemoo.shipping.repository;
+
+import com.lemoo.shipping.entity.ShippingOrder;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ShippingOrderRepository extends MongoRepository<ShippingOrder, String> {
+
+}

--- a/api/Shipping/src/main/java/com/lemoo/shipping/service/impl/ShippingServiceImpl.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/service/impl/ShippingServiceImpl.java
@@ -10,17 +10,22 @@ package com.lemoo.shipping.service.impl;
 import com.lemoo.shipping.client.GhnClient;
 import com.lemoo.shipping.dto.common.ShippingOrderItem;
 import com.lemoo.shipping.dto.request.NewShippingOrderRequest;
+import com.lemoo.shipping.dto.response.GhnShippingOrderResponse;
 import com.lemoo.shipping.dto.response.SkuResponse;
 import com.lemoo.shipping.dto.response.UserResponse;
 import com.lemoo.shipping.entity.ShippingAddress;
+import com.lemoo.shipping.entity.ShippingOrder;
 import com.lemoo.shipping.exception.NotfoundException;
+import com.lemoo.shipping.mapper.ShippingOrderMapper;
 import com.lemoo.shipping.repository.ShippingAddressRepository;
+import com.lemoo.shipping.repository.ShippingOrderRepository;
 import com.lemoo.shipping.service.ShippingService;
 import com.lemoo.shipping.service.SkuService;
 import com.lemoo.shipping.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Set;
 
@@ -32,6 +37,8 @@ public class ShippingServiceImpl implements ShippingService {
     private final UserService userService;
     private final SkuService skuService;
     private final GhnClient ghnClient;
+    private final ShippingOrderMapper shippingOrderMapper;
+    private final ShippingOrderRepository shippingOrderRepository;
 
     @Override
     public void createShippingOrder(
@@ -86,6 +93,12 @@ public class ShippingServiceImpl implements ShippingService {
                 ).toList())
                 .build();
 
-        ghnClient.createShippingOrder(shippingOrderRequest);
+        GhnShippingOrderResponse ghnShippingOrderResponse = ghnClient.createShippingOrder(shippingOrderRequest);
+
+        ShippingOrder shippingOrder = shippingOrderMapper.toShippingOrder(ghnShippingOrderResponse);
+        shippingOrder.setOrderId(orderId);
+        shippingOrder.setUserId(userId);
+        shippingOrder.setExpectedDeliveryTime(LocalDateTime.parse(ghnShippingOrderResponse.getData().getExpected_delivery_time()));
+        shippingOrderRepository.save(shippingOrder);
     }
 }


### PR DESCRIPTION
Implements the creation of shipping orders using the GHN client and persists them to the database.

This change introduces:
- `GhnShippingOrderResponse` DTO to handle GHN API responses.
- `ShippingOrder` entity to represent shipping orders in the database.
- `ShippingOrderMapper` to map GHN responses to `ShippingOrder` entities.
- `ShippingOrderRepository` to manage shipping order persistence.

The shipping order creation process now involves calling the GHN client, mapping the response to a `ShippingOrder` entity, and saving it to the database.