### PR TITLE
Initializes logs set in ShippingOrderResponse

### DIFF
--- a/api/Shipping/src/main/java/com/lemoo/shipping/dto/response/ShippingOrderResponse.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/dto/response/ShippingOrderResponse.java
@@ -15,6 +15,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.HashSet;
 import java.util.Set;
 
 @Data
@@ -27,7 +28,9 @@ public class ShippingOrderResponse {
     private Long totalAmount;
     private String orderId;
     private String shippingAddressId;
-    private Set<ShippingOrderLog> logs;
+    
+    @Builder.Default
+    private Set<ShippingOrderLog> logs = new HashSet<>();
     private ShippingOrder.LeadtimeOrder leadtimeOrder;
     private ShippingOrderStatus status;
 }


### PR DESCRIPTION
Ensures that the logs set in the ShippingOrderResponse is initialized to prevent null pointer exceptions when accessing it.