### PR TITLE
Refactors ShippingOrderLog status to enum

### DIFF
--- a/api/Shipping/src/main/java/com/lemoo/shipping/entity/ShippingOrderLog.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/entity/ShippingOrderLog.java
@@ -7,6 +7,7 @@
 
 package com.lemoo.shipping.entity;
 
+import com.lemoo.shipping.common.enums.ShippingOrderStatus;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ShippingOrderLog {
-    private String status;
+    private ShippingOrderStatus status;
     private String tripCode;
     private String updatedDate;
 }

--- a/api/Shipping/src/main/java/com/lemoo/shipping/mapper/ShippingOrderMapper.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/mapper/ShippingOrderMapper.java
@@ -10,6 +10,7 @@ import com.lemoo.shipping.common.enums.ShippingOrderStatus;
 import com.lemoo.shipping.dto.response.GhnShippingOrderResponse;
 import com.lemoo.shipping.dto.response.ShippingOrderResponse;
 import com.lemoo.shipping.entity.ShippingOrder;
+import com.lemoo.shipping.entity.ShippingOrderLog;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
@@ -40,4 +41,8 @@ public interface ShippingOrderMapper {
     default ShippingOrderStatus mapStatus(String status) {
         return ShippingOrderStatus.fromApiValue(status);
     }
+
+    @Mapping(source = "trip_code", target = "tripCode")
+    @Mapping(source = "updated_date", target = "updatedDate")
+    ShippingOrderLog toShippingOrderLog(GhnShippingOrderResponse.Log log);
 }


### PR DESCRIPTION
Changes the ShippingOrderLog status field from String to ShippingOrderStatus enum for improved type safety and maintainability.

Adds mapper functionality to transform GHN log data into ShippingOrderLog entities.