### PR TITLE
Updates GHN client and shipping order mapping

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -32,5 +32,6 @@
     <file url="file://$PROJECT_DIR$/deployment-private/k8s/app/shipping-deployment.yaml" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/deployment-private/k8s/database/product-db.yaml" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/deployment-private/k8s/database/promotion-db.yaml" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/env/shipping-service.env" charset="UTF-8" />
   </component>
 </project>

--- a/api/Shipping/src/main/java/com/lemoo/shipping/client/GhnClient.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/client/GhnClient.java
@@ -23,11 +23,11 @@ import java.util.List;
 @FeignClient(
         url = "${services.external.ghn}",
         name = "ghn-service",
-        configuration = GhnRequestInterceptor.class
+        configuration = {GhnRequestInterceptor.class}
 )
 public interface GhnClient {
 
-    @GetMapping("v2/shipping-order/detail-by-client-code")
+    @GetMapping("/v2/shipping-order/detail-by-client-code")
     GhnShippingOrderResponse getShippingOrderByClientCode(@RequestParam("client_order_code") String clientCode);
 
     @PostMapping("/v2/shipping-order/create")

--- a/api/Shipping/src/main/java/com/lemoo/shipping/dto/response/GhnShippingOrderResponse.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/dto/response/GhnShippingOrderResponse.java
@@ -7,24 +7,31 @@
 
 package com.lemoo.shipping.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 import java.util.Set;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class GhnShippingOrderResponse {
     private ApiData data;
+    private Integer code;
+    private String message;
 
     @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ApiData {
         private String content;
         private String order_code;
         private String status;
-        private LocalDateTime order_date;
-        private LocalDateTime finish_date;
-        private LocalDateTime pickup_time;
-        private LocalDateTime leadtime;
+        private String order_date;
+        private String finish_date;
+        private String pickup_time;
+        private String leadtime;
         private LeadtimeOrder leadtime_order;
         private Set<Log> logs;
         private Long cod_amount;

--- a/api/Shipping/src/main/java/com/lemoo/shipping/mapper/ShippingOrderMapper.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/mapper/ShippingOrderMapper.java
@@ -2,7 +2,7 @@
  *  ShippingOrderMapper
  *  @author: pc
  *  @created 4/14/2025 11:38 PM
- * */
+ */
 
 package com.lemoo.shipping.mapper;
 
@@ -13,7 +13,10 @@ import com.lemoo.shipping.entity.ShippingOrder;
 import com.lemoo.shipping.entity.ShippingOrderLog;
 import org.mapstruct.*;
 
-@Mapper
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Mapper(componentModel = "spring")
 public interface ShippingOrderMapper {
 
     @Mapping(source = "codAmount", target = "totalAmount")
@@ -22,33 +25,35 @@ public interface ShippingOrderMapper {
     @Mapping(source = "data.content", target = "content")
     @Mapping(source = "data.order_code", target = "shippingOrderCode")
     @Mapping(source = "data.cod_amount", target = "codAmount")
-    @Mapping(source = "data.order_date", target = "orderDate")
-    @Mapping(source = "data.finish_date", target = "finishDate")
-    @Mapping(source = "data.pickup_time", target = "pickupTime")
+    @Mapping(source = "data.order_date", target = "orderDate", qualifiedByName = "stringToLocalDateTime")
+    @Mapping(source = "data.finish_date", target = "finishDate", qualifiedByName = "stringToLocalDateTime")
+    @Mapping(source = "data.pickup_time", target = "pickupTime", qualifiedByName = "stringToLocalDateTime")
     @Mapping(source = "data.leadtime_order", target = "leadtimeOrder")
     @Mapping(source = "data.logs", target = "logs")
-    @Mapping(source = "data.leadtime", target = "expectedDeliveryTime")
+    @Mapping(source = "data.leadtime", target = "expectedDeliveryTime", qualifiedByName = "stringToLocalDateTime")
     @Mapping(source = "data.status", target = "status", qualifiedByName = "mapStatus")
     @Mapping(target = "totalFee", ignore = true)
     @Mapping(target = "orderId", ignore = true)
     @Mapping(target = "userId", ignore = true)
+    @Mapping(target = "shippingAddressId", ignore = true)
     ShippingOrder toShippingOrder(GhnShippingOrderResponse ghnShippingOrderResponse);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     @Mapping(source = "data.content", target = "content")
     @Mapping(source = "data.order_code", target = "shippingOrderCode")
     @Mapping(source = "data.cod_amount", target = "codAmount")
-    @Mapping(source = "data.order_date", target = "orderDate")
-    @Mapping(source = "data.finish_date", target = "finishDate")
-    @Mapping(source = "data.pickup_time", target = "pickupTime")
+    @Mapping(source = "data.order_date", target = "orderDate", qualifiedByName = "stringToLocalDateTime")
+    @Mapping(source = "data.finish_date", target = "finishDate", qualifiedByName = "stringToLocalDateTime")
+    @Mapping(source = "data.pickup_time", target = "pickupTime", qualifiedByName = "stringToLocalDateTime")
     @Mapping(source = "data.leadtime_order", target = "leadtimeOrder")
     @Mapping(source = "data.logs", target = "logs")
-    @Mapping(source = "data.leadtime", target = "expectedDeliveryTime")
+    @Mapping(source = "data.leadtime", target = "expectedDeliveryTime", qualifiedByName = "stringToLocalDateTime")
     @Mapping(source = "data.status", target = "status", qualifiedByName = "mapStatus")
     @Mapping(target = "totalFee", ignore = true)
     @Mapping(target = "orderId", ignore = true)
     @Mapping(target = "userId", ignore = true)
-    void updateShippingOrder(GhnShippingOrderResponse shippingOrderResponse, @MappingTarget ShippingOrder shippingOrder);
+    @Mapping(target = "shippingAddressId", ignore = true)
+    void updateShippingOrder(GhnShippingOrderResponse ghnShippingOrderResponse, @MappingTarget ShippingOrder shippingOrder);
 
     @Named("mapStatus")
     default ShippingOrderStatus mapStatus(String status) {
@@ -56,7 +61,12 @@ public interface ShippingOrderMapper {
     }
 
     @Mapping(source = "trip_code", target = "tripCode")
-    @Mapping(source = "updated_date", target = "updatedDate")
+    @Mapping(source = "updated_date", target = "updatedDate", qualifiedByName = "stringToLocalDateTime")
     @Mapping(source = "status", target = "status", qualifiedByName = "mapStatus")
     ShippingOrderLog toShippingOrderLog(GhnShippingOrderResponse.Log log);
+
+    @Named("stringToLocalDateTime")
+    default LocalDateTime stringToLocalDateTime(String date) {
+        return date != null ? LocalDateTime.parse(date, DateTimeFormatter.ISO_DATE_TIME) : null;
+    }
 }

--- a/api/Shipping/src/main/java/com/lemoo/shipping/service/impl/ShippingServiceImpl.java
+++ b/api/Shipping/src/main/java/com/lemoo/shipping/service/impl/ShippingServiceImpl.java
@@ -112,12 +112,13 @@ public class ShippingServiceImpl implements ShippingService {
     private ShippingOrder updateShippingOrder(String orderId, String userId) {
         // TODO: Handle cache ghn response for this function
         GhnShippingOrderResponse shippingOrderResponse = ghnClient.getShippingOrderByClientCode(orderId);
+        System.out.println("shippingOrderResponse = " + shippingOrderResponse);
         ShippingOrder shippingOrder = shippingOrderRepository.findByOrderIdAndUserId(orderId, userId)
                 .orElse(shippingOrderMapper.toShippingOrder(shippingOrderResponse));
         shippingOrderMapper.updateShippingOrder(shippingOrderResponse, shippingOrder);
         shippingOrder.setOrderId(orderId);
         shippingOrder.setUserId(userId);
-        
+
         return shippingOrderRepository.save(shippingOrder);
     }
 }


### PR DESCRIPTION
Updates the GHN client to correctly fetch shipping order details. Specifically, it adjusts the API endpoint and configuration for the GHN service.

The shipping order mapper is also updated to handle date conversions from string to LocalDateTime and to properly map the status. It also ignores shippingAddressId mapping.