### PR TITLE
Adds user ID to reserve result event

### DIFF
--- a/api/Product/src/main/java/com/lemoo/product/event/consumer/OrderConsumer.java
+++ b/api/Product/src/main/java/com/lemoo/product/event/consumer/OrderConsumer.java
@@ -26,6 +26,7 @@ public class OrderConsumer {
 
         ProductReserveResultEvent reserveResultEvent = ProductReserveResultEvent.builder()
                 .orderId(event.getOrderId())
+                .userId(event.getUserId())
                 .build();
 
         try {

--- a/api/Product/src/main/java/com/lemoo/product/event/eventModel/ProductReserveResultEvent.java
+++ b/api/Product/src/main/java/com/lemoo/product/event/eventModel/ProductReserveResultEvent.java
@@ -16,5 +16,6 @@ import lombok.*;
 @Data
 public class ProductReserveResultEvent extends Event {
     private String orderId;
+    private String userId;
     private String message;
 }


### PR DESCRIPTION
Includes the user ID in the product reserve result event.

This ensures that the consumer of the event has access to the user ID associated with the order, enabling more efficient processing and tracking.