### PR TITLE
Enables order history retrieval for chat AI

### DIFF
--- a/api/Chat_ai/src/main/java/com/lemoo/chat_ai/service/impl/ChatServiceImpl.java
+++ b/api/Chat_ai/src/main/java/com/lemoo/chat_ai/service/impl/ChatServiceImpl.java
@@ -33,6 +33,9 @@ public class ChatServiceImpl implements ChatService {
         String conversationId = chatMemoryService.getConversationId(account.getUserId());
 
         String response = chatClient.prompt()
+                .system("user id: " + account.getUserId())
+                .system("user accountId: " + account.getId())
+                .system("user email: " + account.getEmail())
                 .user(request.getMessage())
                 .messages(chatMemoryService.getAllMessages(conversationId))
                 .call().content();

--- a/api/Chat_ai_mcp_server/src/main/java/com/lemoo/chat_ai_mcp_server/client/OrderClient.java
+++ b/api/Chat_ai_mcp_server/src/main/java/com/lemoo/chat_ai_mcp_server/client/OrderClient.java
@@ -1,0 +1,23 @@
+/*
+ *  SearchClient
+ *  @author: pc
+ *  @created 4/18/2025 12:40 AM
+ * */
+
+
+package com.lemoo.chat_ai_mcp_server.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "order-service", url = "${services.order-service}/internal")
+public interface OrderClient {
+    @GetMapping("/users/{userId}")
+    Object getAllUserOrder(
+            @PathVariable("userId") String userId,
+            @RequestParam(value = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(value = "limit", required = false, defaultValue = "10") int limit
+    );
+}

--- a/api/Chat_ai_mcp_server/src/main/java/com/lemoo/chat_ai_mcp_server/common/enum/OrderStatus.java
+++ b/api/Chat_ai_mcp_server/src/main/java/com/lemoo/chat_ai_mcp_server/common/enum/OrderStatus.java
@@ -1,0 +1,65 @@
+/*
+ *  OrderStatus
+ *  @author: Minhhieuano
+ *  @created 3/11/2025 1:25 AM
+ * */
+
+
+package com.lemoo.chat_ai_mcp_server.common;
+
+/**
+ * Represents the possible statuses of an order in an e-commerce system.
+ * This enum defines the lifecycle of an order from creation to completion or cancellation.
+ */
+public enum OrderStatus {
+
+    /**
+     * The order has been created but payment has not yet been completed.
+     */
+    UN_PAID,
+
+    /**
+     * The order has been placed and is awaiting confirmation from the seller.
+     */
+    PENDING,
+
+    /**
+     * The order has been cancelled by the buyer or seller before it is processed further.
+     */
+    CANCELLED,
+
+    /**
+     * The order has been confirmed by the seller and is ready for processing.
+     */
+    CONFIRMED,
+
+    /**
+     * The order has been packed and ready to ship
+     */
+    PACKED,
+
+    /**
+     * The order has been handed over to the shipping provider for delivery.
+     */
+    SHIPPED,
+
+    /**
+     * The order is currently in transit, moving from the seller to the buyer.
+     */
+    IN_TRANSIT,
+
+    /**
+     * The delivery attempt failed (e.g., buyer not available, incorrect address).
+     */
+    FAILED_DELIVERY,
+
+    /**
+     * The order has been successfully delivered to the buyer.
+     */
+    DELIVERED,
+
+    /**
+     * The order process is fully completed, typically after delivery and no further actions are required.
+     */
+    COMPLETED
+}

--- a/api/Chat_ai_mcp_server/src/main/java/com/lemoo/chat_ai_mcp_server/common/enum/PaymentMethod.java
+++ b/api/Chat_ai_mcp_server/src/main/java/com/lemoo/chat_ai_mcp_server/common/enum/PaymentMethod.java
@@ -1,0 +1,20 @@
+/*
+ *  PaymentType
+ *  @author: Minhhieuano
+ *  @created 3/11/2025 5:34 PM
+ * */
+
+
+package com.lemoo.chat_ai_mcp_server.common;
+
+public enum PaymentMethod {
+    /**
+     * Cash on Delivery - Payment is made in cash when the order is delivered to the buyer.
+     */
+    COD,
+
+    /**
+     * Payment via MoMo - Payment is made through the MoMo mobile payment platform.
+     */
+    MOMO
+}

--- a/api/Chat_ai_mcp_server/src/main/java/com/lemoo/chat_ai_mcp_server/dto/response/OrderItemResponse.java
+++ b/api/Chat_ai_mcp_server/src/main/java/com/lemoo/chat_ai_mcp_server/dto/response/OrderItemResponse.java
@@ -1,0 +1,22 @@
+/*
+ *  OrderItemResponse
+ *  @author: Minhhieuano
+ *  @created 3/10/2025 11:58 PM
+ * */
+
+
+package com.lemoo.chat_ai_mcp_server.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class OrderItemResponse {
+    private String lemooSku;
+    private String name;
+    private String image;
+    private String storeId;
+    private Integer quantity;
+    private Long price;
+}

--- a/api/Chat_ai_mcp_server/src/main/java/com/lemoo/chat_ai_mcp_server/dto/response/OrderResponse.java
+++ b/api/Chat_ai_mcp_server/src/main/java/com/lemoo/chat_ai_mcp_server/dto/response/OrderResponse.java
@@ -1,0 +1,30 @@
+/*
+ *  OrderResponseDto
+ *  @author: Minhhieuano
+ *  @created 3/10/2025 11:56 PM
+ * */
+
+
+package com.lemoo.chat_ai_mcp_server.dto.response;
+
+import com.lemoo.chat_ai_mcp_server.common.OrderStatus;
+import com.lemoo.chat_ai_mcp_server.common.PaymentMethod;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@Data
+@Builder
+public class OrderResponse {
+    private String id;
+    private Set<OrderItemResponse> items;
+    private Long total;
+    //    private ShippingAddressResponse shippingAddress;
+    private PaymentMethod paymentMethod;
+    private OrderStatus status;
+    private LocalDateTime orderDate;
+    private String storeId;
+    private Set<String> vouchers;
+}

--- a/api/Chat_ai_mcp_server/src/main/java/com/lemoo/chat_ai_mcp_server/dto/response/PageableResponse.java
+++ b/api/Chat_ai_mcp_server/src/main/java/com/lemoo/chat_ai_mcp_server/dto/response/PageableResponse.java
@@ -1,0 +1,17 @@
+package com.lemoo.chat_ai_mcp_server.dto.response;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class PageableResponse<T> {
+    private int totalPages;
+    private int totalElements;
+    private int size;
+    private List<T> content;
+    private boolean first;
+    private boolean last;
+    private int pageNumber;
+    private boolean empty;
+}

--- a/api/Chat_ai_mcp_server/src/main/java/com/lemoo/chat_ai_mcp_server/service/OrderService.java
+++ b/api/Chat_ai_mcp_server/src/main/java/com/lemoo/chat_ai_mcp_server/service/OrderService.java
@@ -1,0 +1,29 @@
+/*
+ *  OrderService
+ *  @author: pc
+ *  @created 4/21/2025 7:55 PM
+ * */
+
+
+package com.lemoo.chat_ai_mcp_server.service;
+
+import com.lemoo.chat_ai_mcp_server.client.OrderClient;
+import com.lemoo.chat_ai_mcp_server.dto.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderClient orderClient;
+
+    @Tool(
+            name = "findAllUserOrder",
+            description = "Retrieves a paginated list of all orders for a specific user based on their user ID. The tool returns an API response containing order details including order ID, items, total amount, payment method, order status, order date, store ID, and applied vouchers. The results are paginated, with 'page' specifying the page number (starting from 0) and 'limit' specifying the number of orders per page. Default values are page = 0 and limit = 20."
+    )
+    public ApiResponse<?> findAllUserOrder(String userId, int page, int limit) {
+        return ApiResponse.success(orderClient.getAllUserOrder(userId, page, limit));
+    }
+}

--- a/api/Chat_ai_mcp_server/src/main/resources/application.yml
+++ b/api/Chat_ai_mcp_server/src/main/resources/application.yml
@@ -16,3 +16,4 @@ server:
 
 services:
   search-service: ${SEARCH_SERVICE_URL:http://localhost:8000/search}
+  order-service: ${ORDER_SERVICE_URL:http://localhost:8080/order}

--- a/api/Order_v2/src/main/java/com/lemoo/order_v2/config/SecurityConfig.java
+++ b/api/Order_v2/src/main/java/com/lemoo/order_v2/config/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
                 .exceptionHandling(handler -> handler.authenticationEntryPoint(authenticationEntryPoint)
                         .accessDeniedHandler(accessDeniedHandler))
                 .authorizeHttpRequests(request -> request
+                        .requestMatchers("/internal/**").permitAll()
                         .requestMatchers("/orders/seller/**").hasRole("SELLER")
                         .anyRequest().authenticated())
                 .oauth2ResourceServer(

--- a/api/Order_v2/src/main/java/com/lemoo/order_v2/controller/InternalOrderController.java
+++ b/api/Order_v2/src/main/java/com/lemoo/order_v2/controller/InternalOrderController.java
@@ -1,0 +1,29 @@
+/*
+ *  InternalOrderController
+ *  @author: pc
+ *  @created 4/21/2025 7:56 PM
+ * */
+
+
+package com.lemoo.order_v2.controller;
+
+import com.lemoo.order_v2.dto.response.ApiResponse;
+import com.lemoo.order_v2.service.InternalOrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/internal")
+@RequiredArgsConstructor
+public class InternalOrderController {
+    private final InternalOrderService internalOrderService;
+
+    @GetMapping("/users/{userId}")
+    public ApiResponse<?> getAllUserOrder(
+            @PathVariable("userId") String userId,
+            @RequestParam(value = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(value = "limit", required = false, defaultValue = "10") int limit
+    ) {
+        return ApiResponse.success(internalOrderService.getAllOrders(userId, page, limit));
+    }
+}

--- a/api/Order_v2/src/main/java/com/lemoo/order_v2/service/InternalOrderService.java
+++ b/api/Order_v2/src/main/java/com/lemoo/order_v2/service/InternalOrderService.java
@@ -1,0 +1,15 @@
+/*
+ *  InternalOrderService
+ *  @author: pc
+ *  @created 4/21/2025 7:57 PM
+ * */
+
+package com.lemoo.order_v2.service;
+
+
+import com.lemoo.order_v2.dto.response.OrderResponse;
+import com.lemoo.order_v2.dto.response.PageableResponse;
+
+public interface InternalOrderService {
+    PageableResponse<OrderResponse> getAllOrders(String userId, int page, int limit);
+}

--- a/api/Order_v2/src/main/java/com/lemoo/order_v2/service/impl/InternalOrderServiceImpl.java
+++ b/api/Order_v2/src/main/java/com/lemoo/order_v2/service/impl/InternalOrderServiceImpl.java
@@ -1,0 +1,36 @@
+/*
+ *  InternalOrderServiceImpl
+ *  @author: pc
+ *  @created 4/21/2025 7:58 PM
+ * */
+
+
+package com.lemoo.order_v2.service.impl;
+
+import com.lemoo.order_v2.dto.response.OrderResponse;
+import com.lemoo.order_v2.dto.response.PageableResponse;
+import com.lemoo.order_v2.entity.Order;
+import com.lemoo.order_v2.mapper.OrderMapper;
+import com.lemoo.order_v2.mapper.PageMapper;
+import com.lemoo.order_v2.repository.OrderRepository;
+import com.lemoo.order_v2.service.InternalOrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class InternalOrderServiceImpl implements InternalOrderService {
+    private final OrderRepository orderRepository;
+    private final PageMapper pageMapper;
+    private final OrderMapper orderMapper;
+
+    @Override
+    public PageableResponse<OrderResponse> getAllOrders(String userId, int page, int limit) {
+        PageRequest pageRequest = PageRequest.of(page, limit);
+        Page<Order> orders = orderRepository.findAllByUserId(userId, pageRequest);
+        Page<OrderResponse> orderItemResponses = orders.map(orderMapper::toOrderResponse);
+        return pageMapper.toPageableResponse(orderItemResponses);
+    }
+}


### PR DESCRIPTION
Adds functionality to retrieve user order history via an internal API.

This change introduces an `OrderClient` using Feign to communicate with the order service, and exposes an endpoint to allow the chat AI to access and display a user's order information.  This enables the AI to provide more personalized and context-aware responses related to order status and history.

Adds user information to chat prompt to improve context.