### PR TITLE
Displays product description on detail page

### DIFF
--- a/ui/lemoo_mall/src/components/modules/product/product-detail/ProductDetail.tsx
+++ b/ui/lemoo_mall/src/components/modules/product/product-detail/ProductDetail.tsx
@@ -35,6 +35,12 @@ const ProductDetail = () => {
                         {/* Shop Section */}
                         <StoreSection />
                     </section>
+                    <div
+                        className="col-span-12"
+                        dangerouslySetInnerHTML={{
+                            __html: productData.description,
+                        }}
+                    />
                 </div>
             </div>
         </ProductDetailProvider>


### PR DESCRIPTION
Adds the product description to the product detail page.

The description is rendered using `dangerouslySetInnerHTML` to allow for HTML content in the description.